### PR TITLE
one way to ensure that top level describe does not work inside the dsl

### DIFF
--- a/failgood/src/main/kotlin/failgood/ContextDSL.kt
+++ b/failgood/src/main/kotlin/failgood/ContextDSL.kt
@@ -1,5 +1,7 @@
 package failgood
 
+import kotlin.reflect.KClass
+
 interface ResourcesDSL {
     /**
      * asynchronously create a dependency. This is great for blocking dependencies, like a docker container.
@@ -46,5 +48,17 @@ interface ContextDSL : ResourcesDSL {
      * define a pending test.
      */
     suspend fun pending(behaviorDescription: String, function: TestLambda = {})
+
+    @Deprecated("top level describe should not be used inside the context DSL", level = DeprecationLevel.ERROR)
+    fun describe(subjectDescription: String, disabled: Boolean = false, function: ContextLambda) {
+    }
+
+    @Deprecated("top level describe should not be used inside the context DSL", level = DeprecationLevel.ERROR)
+    fun <T> describe(disabled: Boolean = false, function: ContextLambda) {
+    }
+
+    @Deprecated("top level describe should not be used inside the context DSL", level = DeprecationLevel.ERROR)
+    fun describe(subjectType: KClass<*>, disabled: Boolean = false, function: ContextLambda) {
+    }
 
 }

--- a/failgood/src/test/kotlin/failgood/DescribeTest.kt
+++ b/failgood/src/test/kotlin/failgood/DescribeTest.kt
@@ -6,9 +6,10 @@ import strikt.assertions.isEqualTo
 
 @Testable
 class DescribeTest {
+    val desc = describe(String::class) {}
     val context = describe("The describe top level method") {
         it("creates a context named 'The <className>' when called with a class") {
-            expectThat(describe(String::class) {}) {
+            expectThat(desc) {
                 get { name }.isEqualTo("The String")
             }
         }

--- a/failgood/src/test/kotlin/failgood/internal/SingleTestExecutorTest.kt
+++ b/failgood/src/test/kotlin/failgood/internal/SingleTestExecutorTest.kt
@@ -51,7 +51,7 @@ class SingleTestExecutorTest {
             }
             it("also supports describe / it") {
                 val context =
-                    describe(ContextExecutor::class) {
+                    RootContext("root") {
                         describe("with a valid root context") {
                             it("returns number of tests") {}
                             it("returns contexts") {}
@@ -59,7 +59,7 @@ class SingleTestExecutorTest {
                     }
                 val test =
                     ContextPath(
-                        Context("with a valid root context", Context("ContextExecutor", null)),
+                        Context("with a valid root context", Context("root", null)),
                         "returns contexts"
                     )
                 val executor = SingleTestExecutor(context, test, testDSL, resourceCloser)

--- a/failgood/src/test/kotlin/failgood/problematic/RootLevelDescribe.kt
+++ b/failgood/src/test/kotlin/failgood/problematic/RootLevelDescribe.kt
@@ -1,0 +1,16 @@
+package failgood.problematic
+
+import failgood.describe
+import org.junit.platform.commons.annotation.Testable
+
+// this is confusing and should not compile:
+@Testable
+class RootLevelDescribe {
+    val context = describe("root") {
+/*        describe(RootLevelDescribe::class) {
+            it("should not compile") {
+
+            }
+        }*/
+    }
+}


### PR DESCRIPTION
add copies of the methods to the context dsl with deprecation level error. 
one downside of this is that idea shows the deprecated methods in code completion: 

<img width="657" alt="image" src="https://user-images.githubusercontent.com/1999/119506213-fdad2580-bd6d-11eb-8e6a-09d20f0c7b6d.png">


also it feels a bit wrong. related to #18 