### PR TITLE
Simplify handling content of a channel

### DIFF
--- a/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
+++ b/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
@@ -82,13 +82,14 @@ class FailGoodJunitTestEngine : TestEngine {
                 LoggingEngineExecutionListener(request.engineExecutionListener), failureLogger
             )
             junitListener.executionStarted(root)
+
             // report failed contexts as failed immediately
-            val failedRootContexts: MutableList<FailedRootContext> = root.failedRootContexts
-            failedRootContexts.forEach {
+            root.failedRootContexts.forEach {
                 val testDescriptor = mapper.getMapping(it.context)
                 junitListener.executionStarted(testDescriptor)
                 junitListener.executionFinished(testDescriptor, TestExecutionResult.failed(it.failure))
             }
+
             val executionListener = root.executionListener
             val results = runBlocking(suiteExecutionContext.coroutineDispatcher) {
                 // report results while they come in. we use a channel because tests were already running before the execute

--- a/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
+++ b/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
@@ -106,9 +106,9 @@ class FailGoodJunitTestEngine : TestEngine {
                         val mapping = mapper.getMappingOrNull(description)
                         // it's possible that we get a test event for a test that has no mapping because it is part of a failing context
                         if (mapping == null) {
-                            // it's a failing root context, so ignore it
                             if (description.container.parents.isNotEmpty())
                                 throw FailGoodException("did not find mapping for event $event.")
+                            // it's a failing root context, so ignore it
                             return@consumeEach
                         }
                         when (event) {


### PR DESCRIPTION
Use the existing convenience function to consume each element of a channel until the channel is closed