### PR TITLE
Enforce strong null-safety for reading environment variables

### DIFF
--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -6,6 +6,7 @@ import failgood.internal.ContextInfo
 import failgood.internal.ContextTreeReporter
 import failgood.internal.ExecuteAllTestFilterProvider
 import failgood.internal.TestFilterProvider
+import failgood.util.getenv
 import kotlinx.coroutines.*
 import java.lang.management.ManagementFactory
 import kotlin.reflect.KClass
@@ -33,7 +34,7 @@ class Suite(val contextProviders: Collection<ContextProvider>) {
     }
 
     // set timeout to the timeout in milliseconds, an empty string to turn it off
-    private val timeoutMillis: Long = System.getenv("TIMEOUT").let {
+    private val timeoutMillis: Long = getenv("TIMEOUT").let {
         when (it) {
             null -> DEFAULT_TIMEOUT
             "" -> null
@@ -47,7 +48,7 @@ class Suite(val contextProviders: Collection<ContextProvider>) {
         executionFilter: TestFilterProvider = ExecuteAllTestFilterProvider,
         listener: ExecutionListener = NullExecutionListener
     ): List<Deferred<ContextResult>> {
-        val tag = System.getenv("FAILGOOD_TAG")
+        val tag = getenv("FAILGOOD_TAG")
         return contextProviders
             .map {
                 coroutineScope.async {

--- a/failgood/jvm/src/failgood/SuiteResult.kt
+++ b/failgood/jvm/src/failgood/SuiteResult.kt
@@ -4,6 +4,7 @@ import failgood.internal.Colors
 import failgood.internal.ContextTreeReporter
 import failgood.internal.FailedRootContext
 import failgood.internal.Junit4Reporter
+import failgood.util.getenv
 import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.system.exitProcess
@@ -30,7 +31,7 @@ data class SuiteResult(
         }
         val totalTests = allTests.size
         if (allOk) {
-            if (System.getenv("PRINT_SLOWEST") != null)
+            if (getenv("PRINT_SLOWEST") != null)
                 printSlowestTests()
             val pendingTests = allTests.filter { it.isPending }
             if (pendingTests.isNotEmpty()) {

--- a/failgood/jvm/src/failgood/internal/SuiteExecutionContext.kt
+++ b/failgood/jvm/src/failgood/internal/SuiteExecutionContext.kt
@@ -1,13 +1,14 @@
 package failgood.internal
 
 import failgood.cpus
+import failgood.util.getenv
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-private val envParallelism: Int? = System.getenv("FAILGOOD_PARALLELISM")?.toInt()
+private val envParallelism = getenv("FAILGOOD_PARALLELISM")?.toInt()
 
 class SuiteExecutionContext(parallelismOverride: Int? = null) : AutoCloseable {
     // constructor parameter overrides system env variable overrides number of cpus autodetect

--- a/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
+++ b/failgood/jvm/src/failgood/junit/FailGoodJunitTestEngine.kt
@@ -5,6 +5,7 @@ import failgood.internal.*
 import failgood.junit.FailGoodJunitTestEngineConstants.CONFIG_KEY_DEBUG
 import failgood.junit.FailGoodJunitTestEngineConstants.RUN_TEST_FIXTURES
 import failgood.junit.JunitExecutionListener.TestExecutionEvent
+import failgood.util.getenv
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import org.junit.platform.engine.*
@@ -19,7 +20,7 @@ import kotlin.system.exitProcess
 const val CONTEXT_SEGMENT_TYPE = "class"
 const val TEST_SEGMENT_TYPE = "method"
 
-private val watchdog = System.getenv("FAILGOOD_WATCHDOG_MILLIS")?.toLong()
+private val watchdog = getenv("FAILGOOD_WATCHDOG_MILLIS")?.toLong()
 
 class FailGoodJunitTestEngine : TestEngine {
     private var debug: Boolean = false
@@ -44,7 +45,7 @@ class FailGoodJunitTestEngine : TestEngine {
             return EngineDescriptor(uniqueId, FailGoodJunitTestEngineConstants.displayName)
         val suite = Suite(providers)
         val suiteExecutionContext = SuiteExecutionContext()
-        val filterProvider = contextsAndFilters.filter ?: System.getenv("FAILGOOD_FILTER")
+        val filterProvider = contextsAndFilters.filter ?: getenv("FAILGOOD_FILTER")
             ?.let { StaticTestFilterProvider(StringListTestFilter(parseFilterString(it))) }
         val testResult = runBlocking(suiteExecutionContext.coroutineDispatcher) {
             val testResult = suite.findTests(
@@ -177,7 +178,7 @@ class FailGoodJunitTestEngine : TestEngine {
             junitListener.executionFinished(root, TestExecutionResult.successful())
 // for debugging println(junitListener.events.joinToString("\n"))
 
-            if (System.getenv("PRINT_SLOWEST") != null) results.printSlowestTests()
+            if (getenv("PRINT_SLOWEST") != null) results.printSlowestTests()
             suiteExecutionContext.close()
         } catch (e: Throwable) {
             failureLogger.fail(e)

--- a/failgood/jvm/src/failgood/util/getenv.kt
+++ b/failgood/jvm/src/failgood/util/getenv.kt
@@ -1,0 +1,3 @@
+package failgood.util
+
+internal fun getenv(name: String): String? = System.getenv(name)

--- a/failgood/jvm/test/failgood/FailGoodBootstrap.kt
+++ b/failgood/jvm/test/failgood/FailGoodBootstrap.kt
@@ -1,5 +1,6 @@
 package failgood
 
+import failgood.util.getenv
 import kotlinx.coroutines.CompletableDeferred
 import strikt.api.expectThat
 import strikt.assertions.all
@@ -55,6 +56,6 @@ suspend fun main() {
 
     // let's see how far we can get with one second.
     // on CI everything is much slower, and we don't want to randomly fail ci so lets use 4000 for now
-    val limit: Long = if (System.getenv("CI") != null) 4000 else 1000
+    val limit: Long = if (getenv("CI") != null) 4000 else 1000
     expectThat(ManagementFactory.getRuntimeMXBean().uptime).isLessThan(limit)
 }


### PR DESCRIPTION
Using Kotlins strong null-safety when accessing system environment variables helps to always remember to handle the case that this environment variable can be unset and thus avoiding unexpected NullPointerExceptions.