### PR TITLE
show how isolation would look like with an enum

### DIFF
--- a/failgood/jvm/src/failgood/ContextDSL.kt
+++ b/failgood/jvm/src/failgood/ContextDSL.kt
@@ -50,7 +50,7 @@ interface ContextDSL<GivenType> : ResourcesDSL {
     suspend fun <ContextDependency> describe(
         name: String,
         tags: Set<String> = setOf(),
-        isolation: Boolean? = null,
+        isolation: Isolation = Isolation.KEEP,
         given: (suspend () -> ContextDependency),
         contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
     )
@@ -62,7 +62,7 @@ interface ContextDSL<GivenType> : ResourcesDSL {
     suspend fun describe(
         name: String,
         tags: Set<String> = setOf(),
-        isolation: Boolean? = null,
+        isolation: Isolation = Isolation.KEEP,
         function: ContextLambda
     )
 
@@ -88,7 +88,7 @@ interface ContextDSL<GivenType> : ResourcesDSL {
     suspend fun <ContextDependency> context(
         name: String,
         tags: Set<String> = setOf(),
-        isolation: Boolean? = null,
+        isolation: Isolation = Isolation.KEEP,
         given: (suspend () -> ContextDependency),
         contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
     )
@@ -99,7 +99,7 @@ interface ContextDSL<GivenType> : ResourcesDSL {
     suspend fun context(
         name: String,
         tags: Set<String> = setOf(),
-        isolation: Boolean? = null,
+        isolation: Isolation = Isolation.KEEP,
         function: ContextLambda
     )
 
@@ -107,4 +107,8 @@ interface ContextDSL<GivenType> : ResourcesDSL {
      * Define a test. Prefer [it]
      */
     suspend fun test(name: String, tags: Set<String> = setOf(), function: TestLambda<GivenType>)
+}
+
+enum class Isolation {
+    KEEP, OFF
 }

--- a/failgood/jvm/src/failgood/FailGood.kt
+++ b/failgood/jvm/src/failgood/FailGood.kt
@@ -62,7 +62,7 @@ inline fun <reified T> describe(
 
 suspend inline fun <reified Class> ContextDSL<*>.describe(
     tags: Set<String> = setOf(),
-    isolation: Boolean? = null,
+    isolation: Isolation = Isolation.KEEP,
     noinline contextLambda: ContextLambda
 ) =
     this.describe(Class::class.simpleName!!, tags, isolation, contextLambda)

--- a/failgood/jvm/src/failgood/internal/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/ContextExecutor.kt
@@ -188,14 +188,14 @@ internal class ContextExecutor constructor(
         override suspend fun <ContextDependency> context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: (suspend () -> ContextDependency),
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) {
             checkForDuplicateName(name)
             if (!executeAll && (filteringByTag && !tags.contains(onlyTag)))
                 return
-            if (isolation == false)
+            if (isolation == Isolation.OFF)
                 containsContextsWithoutIsolation = true
 
             // if we already ran a test in this context we don't need to visit the child context now
@@ -210,15 +210,8 @@ internal class ContextExecutor constructor(
 
             if (processedTests.contains(contextPath)) return
             val sourceInfo = sourceInfo()
-            val subContextShouldHaveIsolation = isolation != false && this.isolation
+            val subContextShouldHaveIsolation = isolation == Isolation.KEEP && this.isolation
             val context = Context(name, context, sourceInfo, subContextShouldHaveIsolation)
-            if (isolation == true && !this.isolation) {
-                recordContextAsFailed(
-                    context, sourceInfo, contextPath,
-                    FailGoodException("in a context without isolation it can not be turned on again")
-                )
-                return
-            }
             val visitor = ContextVisitor(context, resourcesCloser, filteringByTag, given)
             this.mutable = false
             try {
@@ -249,7 +242,7 @@ internal class ContextExecutor constructor(
         override suspend fun context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {
             context(name, tags, isolation, {}, function)
@@ -258,7 +251,7 @@ internal class ContextExecutor constructor(
         override suspend fun <ContextDependency> describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: suspend () -> ContextDependency,
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) = context(name, tags, isolation, given, contextLambda)
@@ -277,7 +270,7 @@ internal class ContextExecutor constructor(
         override suspend fun describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {
             context(name, tags, isolation, function)

--- a/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
@@ -33,7 +33,7 @@ internal class SingleTestExecutor(
         override suspend fun <ContextDependency> context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: (suspend () -> ContextDependency),
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) {
@@ -42,13 +42,13 @@ internal class SingleTestExecutor(
         override suspend fun context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {}
         override suspend fun <ContextDependency> describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: suspend () -> ContextDependency,
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) {
@@ -57,7 +57,7 @@ internal class SingleTestExecutor(
         override suspend fun describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {
         }
@@ -72,7 +72,7 @@ internal class SingleTestExecutor(
         override suspend fun <ContextDependency> context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: suspend () -> ContextDependency,
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) {
@@ -84,7 +84,7 @@ internal class SingleTestExecutor(
         override suspend fun <ContextDependency> describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             given: suspend () -> ContextDependency,
             contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
         ) {
@@ -94,7 +94,7 @@ internal class SingleTestExecutor(
         override suspend fun context(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {
             context(name, tags, isolation, {}, function)
@@ -103,7 +103,7 @@ internal class SingleTestExecutor(
         override suspend fun describe(
             name: String,
             tags: Set<String>,
-            isolation: Boolean?,
+            isolation: Isolation,
             function: ContextLambda
         ) {
             context(name, function = function)

--- a/failgood/jvm/test/failgood/functional/SubContextIsolationTest.kt
+++ b/failgood/jvm/test/failgood/functional/SubContextIsolationTest.kt
@@ -1,5 +1,6 @@
 package failgood.functional
 
+import failgood.Isolation
 import failgood.Suite
 import failgood.Test
 import failgood.assert.containsExactlyInAnyOrder
@@ -19,7 +20,7 @@ object SubContextIsolationTest {
                     Suite(
                         failgood.describe("root") {
                             val events = evt.addEvent()
-                            describe("child", isolation = false) {
+                            describe("child", isolation = Isolation.OFF) {
                                 events.add("childContext")
                                 it("test1") { events.add("test1") }
                                 it("test2") { events.add("test2") }
@@ -34,7 +35,7 @@ object SubContextIsolationTest {
                         Suite(
                             failgood.describe("root") {
                                 val events = evt.addEvent()
-                                describe("child", isolation = false) {
+                                describe("child", isolation = Isolation.OFF) {
                                     events.add("childContext")
                                     it("test1") { events.add("test1") }
                                     it("test2") { events.add("test2") }
@@ -60,7 +61,7 @@ object SubContextIsolationTest {
                     Suite(
                         failgood.describe("root") {
                             val events = evt.addEvent()
-                            describe("child", isolation = false, given = { givenCalls++ }) {
+                            describe("child", isolation = Isolation.OFF, given = { givenCalls++ }) {
                                 events.add("childContext")
                                 it("test1") { given ->
                                     events.add("test1")
@@ -83,7 +84,7 @@ object SubContextIsolationTest {
                         Suite(
                             failgood.describe("root") {
                                 val events = evt.addEvent()
-                                describe("child", isolation = false) {
+                                describe("child", isolation = Isolation.OFF) {
                                     afterEach { events.add("no-isolation-afterEach") }
                                     autoClose("yo") { events.add("no-isolation-autoClose") }
                                     events.add("childContext")
@@ -118,26 +119,6 @@ object SubContextIsolationTest {
                     )
                     assert(e[1] == listOf("child with isolation", "test3"))
                     assert(e[2] == listOf("child with isolation", "test4"))
-                }
-            }
-            describe("error handling") {
-                val e = NestedEvents()
-                it("does not allow to turn isolation on when it was already off") {
-                    val result = Suite(
-                        failgood.describe("root context without isolation", isolation = false) {
-                            describe("sub context that tries to turn isolation on", isolation = true) {
-                                test("this test should never run") {
-                                    e.addEvent()
-                                }
-                            }
-                        }
-                    ).run(silent = true)
-                    val failedContext = assertNotNull(result.failedTests.singleOrNull()?.test)
-                    assert(
-                        failedContext.testName == "error in context" &&
-                            failedContext.container.name == "sub context that tries to turn isolation on"
-                    )
-                    assert(e.globalEvents.isEmpty())
                 }
             }
         }


### PR DESCRIPTION
this has one major problem: you can write isolation=false, and get the wrong (top-level) describe method, so your tests don't run. one design goal is to have top level describe and dsl describe have exactly the same signature to make sure you never use the wrong function.

@mervyn-mccreight , @maandr wdyt?
