### PR TITLE
Refactor context executor

### DIFF
--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -1,7 +1,7 @@
 package failgood
 
 import failgood.internal.*
-import failgood.internal.ContextExecutor
+import failgood.internal.execution.context.ContextExecutor
 import failgood.internal.ContextInfo
 import failgood.internal.ContextTreeReporter
 import failgood.internal.ExecuteAllTestFilterProvider

--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -76,7 +76,7 @@ class Suite(val contextProviders: Collection<ContextProvider>) {
                                     listener,
                                     testFilter,
                                     timeoutMillis,
-                                    onlyTag = tag
+                                    runOnlyTag = tag
                                 ).execute()
                             } else
                                 ContextInfo(emptyList(), mapOf(), setOf())

--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -1,11 +1,11 @@
 package failgood
 
 import failgood.internal.*
-import failgood.internal.execution.context.ContextExecutor
 import failgood.internal.ContextInfo
 import failgood.internal.ContextTreeReporter
 import failgood.internal.ExecuteAllTestFilterProvider
 import failgood.internal.TestFilterProvider
+import failgood.internal.execution.context.ContextExecutor
 import failgood.util.getenv
 import kotlinx.coroutines.*
 import java.lang.management.ManagementFactory

--- a/failgood/jvm/src/failgood/internal/DSLGotoException.kt
+++ b/failgood/jvm/src/failgood/internal/DSLGotoException.kt
@@ -1,0 +1,6 @@
+package failgood.internal
+
+// An exception that we use like a goto. to finish execution of a dsl block when we
+// don't need to execute the rest of the dsl.
+// This exception is caught with an empty catch block.
+open class DSLGotoException : RuntimeException()

--- a/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
@@ -116,5 +116,5 @@ internal class SingleTestExecutor(
         }
     }
 
-    private class TestResultAvailable(val testResult: TestResult) : RuntimeException()
+    private class TestResultAvailable(val testResult: TestResult) : DSLGotoException()
 }

--- a/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/SingleTestExecutor.kt
@@ -7,16 +7,17 @@ import failgood.*
  * Async Called by ContextExecutor to execute all tests that it does not have to execute itself
  */
 internal class SingleTestExecutor(
-    private val context: RootContext,
     private val test: ContextPath,
     val testDSL: TestDSL,
-    val resourcesCloser: ResourcesCloser
+    val resourcesCloser: ResourcesCloser,
+    val rootContextLambda: ContextLambda
 ) {
     private val startTime = System.nanoTime()
+
     suspend fun execute(): TestResult {
         val dsl: ContextDSL<Unit> = contextDSL({}, test.container.path.drop(1))
         return try {
-            dsl.(context.function)()
+            dsl.(rootContextLambda)()
             throw FailGoodException(
                 "test not found: $test.\n" +
                     "please make sure your test names contain no random parts"

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -22,8 +22,6 @@ internal class ContextExecutor(
         if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT,
         runOnlyTag
     )
-    override var startTime = System.nanoTime()
-
     // did we find contexts without isolation in this root context?
     // in that case we have to call the resources closer after suite.
     override var containsContextsWithoutIsolation = !rootContext.isolation
@@ -56,7 +54,7 @@ internal class ContextExecutor(
         try {
             withTimeout(staticExecutionConfig.timeoutMillis) {
                 do {
-                    startTime = System.nanoTime()
+                    val startTime = System.nanoTime()
                     val resourcesCloser = OnlyResourcesCloser(staticExecutionConfig.scope)
                     val visitor = ContextVisitor(
                         staticExecutionConfig,
@@ -65,7 +63,8 @@ internal class ContextExecutor(
                         {},
                         resourcesCloser,
                         false,
-                        investigatedContexts.contains(rootContext)
+                        investigatedContexts.contains(rootContext),
+                        startTime
                     )
                     visitor.function()
                     investigatedContexts.add(rootContext)

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -14,7 +14,7 @@ internal class ContextExecutor(
     runOnlyTag: String? = null
 ) : ContextStateCollector {
     private val staticExecutionConfig = StaticContextExecutionConfig(
-        rootContext,
+        rootContext.function,
         scope,
         listener,
         testFilter,

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -66,7 +66,10 @@ internal class ContextExecutor(
                         investigatedContexts.contains(rootContext),
                         startTime
                     )
-                    visitor.function()
+                    try {
+                        visitor.function()
+                    } catch (_: ContextFinished) {
+                    }
                     investigatedContexts.add(rootContext)
                     if (containsContextsWithoutIsolation) {
                         afterSuiteCallbacks.add { resourcesCloser.closeAutoCloseables() }
@@ -96,6 +99,9 @@ internal class ContextExecutor(
         staticExecutionConfig.listener.testFinished(testPlusResult)
     }
 }
+
+// this is thrown when a context is finished an we can not do anything meaningful in this pass
+class ContextFinished : DSLGotoException()
 
 fun sourceInfo(): SourceInfo {
     val runtimeException = RuntimeException()

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -25,7 +25,7 @@ internal class ContextExecutor(
         runOnlyTag
     )
 
-    private val stateCollector = ContextStateCollector(listener, !rootContext.isolation)
+    private val stateCollector = ContextStateCollector(staticExecutionConfig, !rootContext.isolation)
     /**
      * Execute the rootContext.
      *

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -1,6 +1,14 @@
-package failgood.internal
+package failgood.internal.execution.context
 
 import failgood.*
+import failgood.internal.*
+import failgood.internal.ContextInfo
+import failgood.internal.ContextPath
+import failgood.internal.ExecuteAllTests
+import failgood.internal.ResourcesCloser
+import failgood.internal.SingleTestExecutor
+import failgood.internal.TestContext
+import failgood.internal.TestFilter
 import kotlinx.coroutines.*
 
 internal class ContextExecutor constructor(

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -25,7 +25,7 @@ internal class ContextExecutor(
         runOnlyTag
     )
 
-    val stateCollector = ContextStateCollector(listener, !rootContext.isolation)
+    private val stateCollector = ContextStateCollector(listener, !rootContext.isolation)
     /**
      * Execute the rootContext.
      *
@@ -73,7 +73,7 @@ internal class ContextExecutor(
     }
 }
 
-// this is thrown when a context is finished an we can not do anything meaningful in this pass
+// this is thrown when a context is finished, and we can not do anything meaningful in this pass
 class ContextFinished : DSLGotoException()
 
 fun sourceInfo(): SourceInfo {

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -13,6 +13,15 @@ internal class ContextExecutor(
     override val timeoutMillis: Long = 40000L,
     private val runOnlyTag: String? = null
 ) : ContextStateCollector {
+    val staticExecutionConfig = StaticContextExecutionConfig(
+        rootContext,
+        scope,
+        listener,
+        testFilter,
+        timeoutMillis,
+        if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT,
+        runOnlyTag
+    )
     override val coroutineStart: CoroutineStart = if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT
     override var startTime = System.nanoTime()
 
@@ -51,13 +60,14 @@ internal class ContextExecutor(
                     startTime = System.nanoTime()
                     val resourcesCloser = OnlyResourcesCloser(scope)
                     val visitor = ContextVisitor(
+                        staticExecutionConfig,
                         this@ContextExecutor,
                         rootContext,
+                        runOnlyTag,
                         {},
                         resourcesCloser,
                         false,
-                        investigatedContexts.contains(rootContext),
- runOnlyTag
+                        investigatedContexts.contains(rootContext)
                     )
                     visitor.function()
                     investigatedContexts.add(rootContext)

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -86,7 +86,6 @@ internal class ContextExecutor constructor(
         foundContexts.add(context)
         listener.testFinished(testPlusResult)
     }
-
 }
 
 fun sourceInfo(): SourceInfo {
@@ -98,7 +97,7 @@ fun sourceInfo(): SourceInfo {
             !(
                 it.fileName?.let { fileName ->
                     fileName.endsWith("ContextVisitor.kt") ||
-                    fileName.endsWith("ContextExecutor.kt") ||
+                        fileName.endsWith("ContextExecutor.kt") ||
                         fileName.endsWith("ContextDSL.kt")
                 } ?: true
                 )

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -52,7 +52,7 @@ internal class ContextExecutor constructor(
                 do {
                     startTime = System.nanoTime()
                     val resourcesCloser = ResourcesCloser(scope)
-                    val visitor = ContextVisitor(
+                    val visitor = ContextVisitor(this@ContextExecutor,
                         rootContext,
                         resourcesCloser,
                         given = {}
@@ -74,6 +74,7 @@ internal class ContextExecutor constructor(
     }
 
     private inner class ContextVisitor<GivenType>(
+        private val contextExecutor: ContextExecutor,
         private val context: Context,
         private val resourcesCloser: ResourcesCloser,
         // execute subcontexts and tests regardless of their tags, even when filtering
@@ -225,7 +226,7 @@ internal class ContextExecutor constructor(
                 )
                 return
             }
-            val visitor = ContextVisitor(context, resourcesCloser, filteringByTag, given)
+            val visitor = ContextVisitor(contextExecutor, context, resourcesCloser, filteringByTag, given)
             this.mutable = false
             try {
                 visitor.mutable = true

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -5,7 +5,7 @@ import failgood.internal.*
 import kotlinx.coroutines.*
 
 internal class ContextExecutor constructor(
-    private val rootContext: RootContext,
+    val rootContext: RootContext,
     val scope: CoroutineScope,
     lazy: Boolean = false,
     val listener: ExecutionListener = NullExecutionListener,
@@ -15,17 +15,17 @@ internal class ContextExecutor constructor(
 ) {
     val filteringByTag = onlyTag != null
     val coroutineStart: CoroutineStart = if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT
-    private var startTime = System.nanoTime()
+    var startTime = System.nanoTime()
 
     // did we find contexts without isolation in this root context?
     // in that case we have to call the resources closer after suite.
-    private var containsContextsWithoutIsolation = !rootContext.isolation
+    var containsContextsWithoutIsolation = !rootContext.isolation
 
-    private val foundContexts = mutableListOf<Context>()
-    private val deferredTestResults = LinkedHashMap<TestDescription, Deferred<TestPlusResult>>()
-    private val processedTests = LinkedHashSet<ContextPath>()
-    private val afterSuiteCallbacks = mutableSetOf<suspend () -> Unit>()
-    private val investigatedContexts = mutableSetOf<Context>()
+    val foundContexts = mutableListOf<Context>()
+    val deferredTestResults = LinkedHashMap<TestDescription, Deferred<TestPlusResult>>()
+    val processedTests = LinkedHashSet<ContextPath>()
+    val afterSuiteCallbacks = mutableSetOf<suspend () -> Unit>()
+    val investigatedContexts = mutableSetOf<Context>()
 
     /**
      * Execute the rootContext.
@@ -67,229 +67,7 @@ internal class ContextExecutor constructor(
         return ContextInfo(contexts, deferredTestResults, afterSuiteCallbacks)
     }
 
-    private class ContextVisitor<GivenType>(
-        private val contextExecutor: ContextExecutor,
-        private val context: Context,
-        private val resourcesCloser: ResourcesCloser,
-        // execute subcontexts and tests regardless of their tags, even when filtering
-        private val executeAll: Boolean = false,
-        val given: (suspend () -> GivenType)
-    ) : ContextDSL<GivenType>, ResourcesDSL by resourcesCloser {
-        val isolation = context.isolation
-        private val contextInvestigated = contextExecutor.investigatedContexts.contains(context)
-        private val namesInThisContext = mutableSetOf<String>() // test and context names to detect duplicates
-
-        // we only run the first new test that we find here. the remaining tests of the context
-        // run with the TestExecutor.
-        private var ranATest = false
-        var contextsLeft = false // are there sub contexts left to run?
-        var mutable = true // we allow changes only to the current context to catch errors in the context structure
-
-        override suspend fun it(name: String, tags: Set<String>, function: TestLambda<GivenType>) {
-            checkForDuplicateName(name)
-            if (!executeAll && (contextExecutor.filteringByTag && !tags.contains(contextExecutor.onlyTag)))
-                return
-            val testPath = ContextPath(context, name)
-            if (!contextExecutor.testFilter.shouldRun(testPath))
-                return
-            // we process each test only once
-            if (!contextExecutor.processedTests.add(testPath)) {
-                return
-            }
-            val testDescription = TestDescription(context, name, sourceInfo())
-            if (!ranATest || !isolation) {
-                // if we don't need isolation we run all tests here.
-                // if we do:
-                // we did not yet run a test, so we are going to run this test ourselves
-                ranATest = true
-
-                contextExecutor.deferredTestResults[testDescription] =
-                    contextExecutor.scope.async(start = contextExecutor.coroutineStart) {
-
-                        contextExecutor.listener.testStarted(testDescription)
-                        val testResult = executeTest(testDescription, function)
-                        val testPlusResult = TestPlusResult(testDescription, testResult)
-                        contextExecutor.listener.testFinished(testPlusResult)
-                        testPlusResult
-                    }
-            } else {
-                val resourcesCloser = ResourcesCloser(contextExecutor.scope)
-                val deferred = contextExecutor.scope.async(start = contextExecutor.coroutineStart) {
-                    contextExecutor.listener.testStarted(testDescription)
-                    val testPlusResult = try {
-                        withTimeout(contextExecutor.timeoutMillis) {
-                            val result =
-                                SingleTestExecutor(
-                                    contextExecutor.rootContext,
-                                    testPath,
-                                    TestContext(resourcesCloser, contextExecutor.listener, testDescription),
-                                    resourcesCloser
-                                ).execute()
-                            TestPlusResult(testDescription, result)
-                        }
-                    } catch (e: TimeoutCancellationException) {
-                        TestPlusResult(testDescription, Failure(e))
-                    }
-                    testPlusResult.also {
-                        contextExecutor.listener.testFinished(it)
-                    }
-                }
-                contextExecutor.deferredTestResults[testDescription] = deferred
-            }
-        }
-
-        private suspend fun executeTest(
-            testDescription: TestDescription,
-            function: TestLambda<GivenType>
-        ): TestResult {
-            return try {
-                withTimeout(contextExecutor.timeoutMillis) {
-                    val testContext = TestContext(resourcesCloser, contextExecutor.listener, testDescription)
-                    try {
-                        testContext.function(given.invoke())
-                    } catch (e: Throwable) {
-                        val failure = Failure(e)
-                        try {
-                            resourcesCloser.callAfterEach(testContext, failure)
-                        } catch (_: Throwable) {
-                        }
-                        if (isolation) try {
-                            resourcesCloser.closeAutoCloseables()
-                        } catch (_: Throwable) {
-                        }
-                        return@withTimeout failure
-                    }
-                    // test was successful
-                    val success = Success((System.nanoTime() - contextExecutor.startTime) / 1000)
-                    try {
-                        resourcesCloser.callAfterEach(testContext, success)
-                    } catch (e: Throwable) {
-                        if (isolation) {
-                            try {
-                                resourcesCloser.closeAutoCloseables()
-                            } catch (e: Throwable) {
-                                return@withTimeout Failure(e)
-                            }
-                        }
-                        return@withTimeout Failure(e)
-                    }
-                    if (isolation) {
-                        try {
-                            resourcesCloser.closeAutoCloseables()
-                        } catch (e: Throwable) {
-                            return@withTimeout Failure(e)
-                        }
-                    }
-                    success
-                }
-            } catch (e: TimeoutCancellationException) {
-                Failure(e)
-            }
-        }
-
-        override suspend fun <ContextDependency> describe(
-            name: String,
-            tags: Set<String>,
-            isolation: Boolean?,
-            given: (suspend () -> ContextDependency),
-            contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
-        ) {
-            checkForDuplicateName(name)
-            if (!executeAll && (contextExecutor.filteringByTag && !tags.contains(contextExecutor.onlyTag)))
-                return
-            if (isolation == false)
-                contextExecutor.containsContextsWithoutIsolation = true
-
-            // if we already ran a test in this context we don't need to visit the child context now
-            if (this.isolation && ranATest) {
-                contextsLeft = true
-                // but we need to run the root context again to visit this child context
-                return
-            }
-            val contextPath = ContextPath(context, name)
-            if (!contextExecutor.testFilter.shouldRun(contextPath))
-                return
-
-            if (contextExecutor.processedTests.contains(contextPath)) return
-            val sourceInfo = sourceInfo()
-            val subContextShouldHaveIsolation = isolation != false && this.isolation
-            val context = Context(name, context, sourceInfo, subContextShouldHaveIsolation)
-            if (isolation == true && !this.isolation) {
-                contextExecutor.recordContextAsFailed(
-                    context, sourceInfo, contextPath,
-                    FailGoodException("in a context without isolation it can not be turned on again")
-                )
-                return
-            }
-            val visitor =
-                ContextVisitor(contextExecutor, context, resourcesCloser, contextExecutor.filteringByTag, given)
-            this.mutable = false
-            try {
-                visitor.mutable = true
-                visitor.contextLambda()
-                visitor.mutable = false
-                this.mutable = true
-                contextExecutor.investigatedContexts.add(context)
-            } catch (exceptionInContext: ImmutableContextException) {
-                // this is fatal, and we treat the whole root context as failed, so we just rethrow
-                throw exceptionInContext
-            } catch (exceptionInContext: Throwable) {
-                this.mutable = true
-                contextExecutor.recordContextAsFailed(context, sourceInfo, contextPath, exceptionInContext)
-                ranATest = true
-                return
-            }
-            if (visitor.contextsLeft) {
-                contextsLeft = true
-            } else {
-                contextExecutor.foundContexts.add(context)
-                contextExecutor.processedTests.add(contextPath)
-            }
-
-            if (visitor.ranATest) ranATest = true
-        }
-
-        override suspend fun describe(
-            name: String,
-            tags: Set<String>,
-            isolation: Boolean?,
-            function: ContextLambda
-        ) {
-            describe(name, tags, isolation, {}, function)
-        }
-
-        private fun checkForDuplicateName(name: String) {
-            if (!namesInThisContext.add(name))
-                throw DuplicateNameInContextException("duplicate name \"$name\" in context \"${context.name}\"")
-            if (!mutable) {
-                throw ImmutableContextException(
-                    "Trying to create a test in the wrong context. " +
-                        "Make sure functions that create tests have ContextDSL as receiver"
-                )
-            }
-        }
-
-        override suspend fun ignore(name: String, function: TestLambda<GivenType>) {
-            val testPath = ContextPath(context, name)
-
-            if (contextExecutor.processedTests.add(testPath)) {
-                val testDescriptor =
-                    TestDescription(context, name, sourceInfo())
-                val result = Pending
-
-                val testPlusResult = TestPlusResult(testDescriptor, result)
-                contextExecutor.deferredTestResults[testDescriptor] = CompletableDeferred(testPlusResult)
-                contextExecutor.listener.testFinished(testPlusResult)
-            }
-        }
-
-        override fun afterSuite(function: suspend () -> Unit) {
-            if (!contextInvestigated)
-                contextExecutor.afterSuiteCallbacks.add(function)
-        }
-    }
-
-    private suspend fun recordContextAsFailed(
+    suspend fun recordContextAsFailed(
         context: Context,
         sourceInfo: SourceInfo,
         contextPath: ContextPath,
@@ -304,11 +82,9 @@ internal class ContextExecutor constructor(
         listener.testFinished(testPlusResult)
     }
 
-    private class DuplicateNameInContextException(s: String) : FailGoodException(s)
-    class ImmutableContextException(s: String) : FailGoodException(s)
 }
 
-private fun sourceInfo(): SourceInfo {
+fun sourceInfo(): SourceInfo {
     val runtimeException = RuntimeException()
     // find the first stack trace element that is not in this class or ContextDSL
     // (ContextDSL because of default parameters defined there)
@@ -316,6 +92,7 @@ private fun sourceInfo(): SourceInfo {
         runtimeException.stackTrace.first {
             !(
                 it.fileName?.let { fileName ->
+                    fileName.endsWith("ContextVisitor.kt") ||
                     fileName.endsWith("ContextExecutor.kt") ||
                         fileName.endsWith("ContextDSL.kt")
                 } ?: true
@@ -323,3 +100,5 @@ private fun sourceInfo(): SourceInfo {
         }!!
     )
 }
+internal class DuplicateNameInContextException(s: String) : FailGoodException(s)
+internal class ImmutableContextException(s: String) : FailGoodException(s)

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -49,12 +49,13 @@ internal class ContextExecutor(
             withTimeout(timeoutMillis) {
                 do {
                     startTime = System.nanoTime()
-                    val resourcesCloser = ResourcesCloser(scope)
+                    val resourcesCloser = OnlyResourcesCloser(scope)
                     val visitor = ContextVisitor(
                         this@ContextExecutor,
                         rootContext,
                         resourcesCloser,
-                        given = {}
+                        given = {},
+                        onlyRunSubcontexts = investigatedContexts.contains(rootContext)
 
                     )
                     visitor.function()

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -11,7 +11,7 @@ internal class ContextExecutor(
     override val listener: ExecutionListener = NullExecutionListener,
     override val testFilter: TestFilter = ExecuteAllTests,
     override val timeoutMillis: Long = 40000L,
-    override val runOnlyTag: String? = null
+    private val runOnlyTag: String? = null
 ) : ContextStateCollector {
     override val coroutineStart: CoroutineStart = if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT
     override var startTime = System.nanoTime()
@@ -28,6 +28,7 @@ internal class ContextExecutor(
 
     // a context is investigated when we have executed it once. we still need to execute it again to get into its sub-contexts
     override val investigatedContexts = mutableSetOf<Context>()
+
     // tests or contexts that we don't have to execute again.
     override val finishedPaths = LinkedHashSet<ContextPath>()
 
@@ -52,10 +53,11 @@ internal class ContextExecutor(
                     val visitor = ContextVisitor(
                         this@ContextExecutor,
                         rootContext,
+                        {},
                         resourcesCloser,
-                        given = {},
-                        onlyRunSubcontexts = investigatedContexts.contains(rootContext)
-
+                        false,
+                        investigatedContexts.contains(rootContext),
+ runOnlyTag
                     )
                     visitor.function()
                     investigatedContexts.add(rootContext)
@@ -95,14 +97,15 @@ fun sourceInfo(): SourceInfo {
     return SourceInfo(
         runtimeException.stackTrace.first {
             !(
-                it.fileName?.let { fileName ->
-                    fileName.endsWith("ContextVisitor.kt") ||
-                        fileName.endsWith("ContextExecutor.kt") ||
-                        fileName.endsWith("ContextDSL.kt")
-                } ?: true
-                )
+                    it.fileName?.let { fileName ->
+                        fileName.endsWith("ContextVisitor.kt") ||
+                                fileName.endsWith("ContextExecutor.kt") ||
+                                fileName.endsWith("ContextDSL.kt")
+                    } ?: true
+                    )
         }!!
     )
 }
+
 internal class DuplicateNameInContextException(s: String) : FailGoodException(s)
 internal class ImmutableContextException(s: String) : FailGoodException(s)

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextExecutor.kt
@@ -11,9 +11,8 @@ internal class ContextExecutor(
     override val listener: ExecutionListener = NullExecutionListener,
     override val testFilter: TestFilter = ExecuteAllTests,
     override val timeoutMillis: Long = 40000L,
-    override val onlyTag: String? = null
+    override val runOnlyTag: String? = null
 ) : ContextStateCollector {
-    override val filteringByTag = onlyTag != null
     override val coroutineStart: CoroutineStart = if (lazy) CoroutineStart.LAZY else CoroutineStart.DEFAULT
     override var startTime = System.nanoTime()
 

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -8,8 +8,6 @@ import failgood.internal.ContextPath
 import kotlinx.coroutines.Deferred
 
 internal interface ContextStateCollector {
-    var startTime: Long
-
     // did we find contexts without isolation in this root context?
     // in that case we have to call the resources closer after suite.
     var containsContextsWithoutIsolation: Boolean

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -14,8 +14,7 @@ internal interface ContextStateCollector {
     val listener: ExecutionListener
     val testFilter: TestFilter
     val timeoutMillis: Long
-    val onlyTag: String?
-    val filteringByTag: Boolean
+    val runOnlyTag: String?
     val coroutineStart: CoroutineStart
     var startTime: Long
 
@@ -23,7 +22,7 @@ internal interface ContextStateCollector {
     // in that case we have to call the resources closer after suite.
     var containsContextsWithoutIsolation: Boolean
 
-    // here we build a list of all the subcontexts in this root context to later return it
+    // here we build a list of all the sub-contexts in this root context to later return it
     val foundContexts: MutableList<Context>
     val deferredTestResults: LinkedHashMap<TestDescription, Deferred<TestPlusResult>>
     val afterSuiteCallbacks: MutableSet<suspend () -> Unit>

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -1,32 +1,41 @@
 package failgood.internal.execution.context
 
-import failgood.Context
-import failgood.SourceInfo
-import failgood.TestDescription
-import failgood.TestPlusResult
+import failgood.*
 import failgood.internal.ContextPath
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 
-internal interface ContextStateCollector {
+internal class ContextStateCollector(
+    val listener: ExecutionListener,
     // did we find contexts without isolation in this root context?
     // in that case we have to call the resources closer after suite.
     var containsContextsWithoutIsolation: Boolean
+) {
 
     // here we build a list of all the sub-contexts in this root context to later return it
-    val foundContexts: MutableList<Context>
-    val deferredTestResults: LinkedHashMap<TestDescription, Deferred<TestPlusResult>>
-    val afterSuiteCallbacks: MutableSet<suspend () -> Unit>
+    val foundContexts = mutableListOf<Context>()
+
+    val deferredTestResults = LinkedHashMap<TestDescription, Deferred<TestPlusResult>>()
+    val afterSuiteCallbacks = mutableSetOf<suspend () -> Unit>()
 
     // a context is investigated when we have executed it once. we still need to execute it again to get into its sub-contexts
-    val investigatedContexts: MutableSet<Context>
+    val investigatedContexts = mutableSetOf<Context>()
 
     // tests or contexts that we don't have to execute again.
-    val finishedPaths: LinkedHashSet<ContextPath>
+    val finishedPaths = LinkedHashSet<ContextPath>()
 
     suspend fun recordContextAsFailed(
         context: Context,
         sourceInfo: SourceInfo,
         contextPath: ContextPath,
         exceptionInContext: Throwable
-    )
+    ) {
+        val testDescriptor = TestDescription(context, "error in context", sourceInfo)
+
+        finishedPaths.add(contextPath) // don't visit this context again
+        val testPlusResult = TestPlusResult(testDescriptor, Failure(exceptionInContext))
+        deferredTestResults[testDescriptor] = CompletableDeferred(testPlusResult)
+        foundContexts.add(context)
+        listener.testFinished(testPlusResult)
+    }
 }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -2,11 +2,12 @@ package failgood.internal.execution.context
 
 import failgood.*
 import failgood.internal.ContextPath
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
+import failgood.internal.ResourcesCloser
+import failgood.internal.TestContext
+import kotlinx.coroutines.*
 
 internal class ContextStateCollector(
-    val listener: ExecutionListener,
+    val staticConfig: StaticContextExecutionConfig,
     // did we find contexts without isolation in this root context?
     // in that case we have to call the resources closer after suite.
     var containsContextsWithoutIsolation: Boolean
@@ -36,6 +37,67 @@ internal class ContextStateCollector(
         val testPlusResult = TestPlusResult(testDescriptor, Failure(exceptionInContext))
         deferredTestResults[testDescriptor] = CompletableDeferred(testPlusResult)
         foundContexts.add(context)
-        listener.testFinished(testPlusResult)
+        staticConfig.listener.testFinished(testPlusResult)
+    }
+    fun <GivenType> executeTest(
+        testDescription: TestDescription,
+        function: TestLambda<GivenType>,
+        resourcesCloser: ResourcesCloser,
+        isolation: Boolean,
+        given: suspend () -> GivenType,
+        rootContextStartTime: Long
+    ) {
+        deferredTestResults[testDescription] =
+            staticConfig.scope.async(start = staticConfig.coroutineStart) {
+
+                val listener = staticConfig.listener
+                listener.testStarted(testDescription)
+                val testResult = try {
+                    withTimeout(staticConfig.timeoutMillis) {
+                        val testContext = TestContext(resourcesCloser, listener, testDescription)
+                        try {
+                            testContext.function(given.invoke())
+                        } catch (e: Throwable) {
+                            val failure = Failure(e)
+                            try {
+                                resourcesCloser.callAfterEach(testContext, failure)
+                            } catch (_: Throwable) {
+                            }
+                            if (isolation) try {
+                                resourcesCloser.closeAutoCloseables()
+                            } catch (_: Throwable) {
+                            }
+                            return@withTimeout failure
+                        }
+                        // test was successful
+                        val success = Success((System.nanoTime() - rootContextStartTime) / 1000)
+                        try {
+                            resourcesCloser.callAfterEach(testContext, success)
+                        } catch (e: Throwable) {
+                            if (isolation) {
+                                try {
+                                    resourcesCloser.closeAutoCloseables()
+                                } catch (e: Throwable) {
+                                    return@withTimeout Failure(e)
+                                }
+                            }
+                            return@withTimeout Failure(e)
+                        }
+                        if (isolation) {
+                            try {
+                                resourcesCloser.closeAutoCloseables()
+                            } catch (e: Throwable) {
+                                return@withTimeout Failure(e)
+                            }
+                        }
+                        success
+                    }
+                } catch (e: TimeoutCancellationException) {
+                    Failure(e)
+                }
+                val testPlusResult = TestPlusResult(testDescription, testResult)
+                listener.testFinished(testPlusResult)
+                testPlusResult
+            }
     }
 }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -42,9 +42,6 @@ internal interface ContextStateCollector {
      */
     suspend fun execute(): ContextResult
     suspend fun recordContextAsFailed(
-        context: Context,
-        sourceInfo: SourceInfo,
-        contextPath: ContextPath,
-        exceptionInContext: Throwable
+        context: Context, sourceInfo: SourceInfo, contextPath: ContextPath, exceptionInContext: Throwable
     )
 }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -1,0 +1,52 @@
+package failgood.internal.execution.context
+
+import failgood.*
+import failgood.internal.ContextPath
+import failgood.internal.ContextResult
+import failgood.internal.TestFilter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+
+internal interface ContextStateCollector {
+    val rootContext: RootContext
+    val scope: CoroutineScope
+    val listener: ExecutionListener
+    val testFilter: TestFilter
+    val timeoutMillis: Long
+    val onlyTag: String?
+    val filteringByTag: Boolean
+    val coroutineStart: CoroutineStart
+    var startTime: Long
+
+    // did we find contexts without isolation in this root context?
+    // in that case we have to call the resources closer after suite.
+    var containsContextsWithoutIsolation: Boolean
+
+    // here we build a list of all the subcontexts in this root context to later return it
+    val foundContexts: MutableList<Context>
+    val deferredTestResults: LinkedHashMap<TestDescription, Deferred<TestPlusResult>>
+    val afterSuiteCallbacks: MutableSet<suspend () -> Unit>
+
+    // a context is investigated when we have executed it once. we still need to execute it again to get into its sub-contexts
+    val investigatedContexts: MutableSet<Context>
+
+    // tests or contexts that we don't have to execute again.
+    val finishedPaths: LinkedHashSet<ContextPath>
+
+    /**
+     * Execute the rootContext.
+     *
+     * We keep executing the Context DSL until we know about all contexts and tests in this root context
+     * The first test in each context is directly executed (async via coroutines), and for all other tests in that
+     * context we create a SingleTestExecutor that executes the whole context path of that test together with the test.
+     *
+     */
+    suspend fun execute(): ContextResult
+    suspend fun recordContextAsFailed(
+        context: Context,
+        sourceInfo: SourceInfo,
+        contextPath: ContextPath,
+        exceptionInContext: Throwable
+    )
+}

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -1,20 +1,13 @@
 package failgood.internal.execution.context
 
-import failgood.*
+import failgood.Context
+import failgood.SourceInfo
+import failgood.TestDescription
+import failgood.TestPlusResult
 import failgood.internal.ContextPath
-import failgood.internal.ContextResult
-import failgood.internal.TestFilter
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 
 internal interface ContextStateCollector {
-    val rootContext: RootContext
-    val scope: CoroutineScope
-    val listener: ExecutionListener
-    val testFilter: TestFilter
-    val timeoutMillis: Long
-    val coroutineStart: CoroutineStart
     var startTime: Long
 
     // did we find contexts without isolation in this root context?
@@ -32,16 +25,10 @@ internal interface ContextStateCollector {
     // tests or contexts that we don't have to execute again.
     val finishedPaths: LinkedHashSet<ContextPath>
 
-    /**
-     * Execute the rootContext.
-     *
-     * We keep executing the Context DSL until we know about all contexts and tests in this root context
-     * The first test in each context is directly executed (async via coroutines), and for all other tests in that
-     * context we create a SingleTestExecutor that executes the whole context path of that test together with the test.
-     *
-     */
-    suspend fun execute(): ContextResult
     suspend fun recordContextAsFailed(
-        context: Context, sourceInfo: SourceInfo, contextPath: ContextPath, exceptionInContext: Throwable
+        context: Context,
+        sourceInfo: SourceInfo,
+        contextPath: ContextPath,
+        exceptionInContext: Throwable
     )
 }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextStateCollector.kt
@@ -14,7 +14,6 @@ internal interface ContextStateCollector {
     val listener: ExecutionListener
     val testFilter: TestFilter
     val timeoutMillis: Long
-    val runOnlyTag: String?
     val coroutineStart: CoroutineStart
     var startTime: Long
 

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -31,7 +31,7 @@ internal class ContextVisitor<GivenType>(
         if (onlyRunSubcontexts)
             return
         checkForDuplicateName(name)
-        if (!executeAll && (staticConfig.runOnlyTag != null && !tags.contains(staticConfig.runOnlyTag)))
+        if (!shouldRun(tags))
             return
         val testPath = ContextPath(context, name)
         if (!staticConfig.testFilter.shouldRun(testPath))
@@ -68,7 +68,7 @@ internal class ContextVisitor<GivenType>(
         contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
     ) {
         checkForDuplicateName(name)
-        if (!executeAll && (staticConfig.runOnlyTag != null && !tags.contains(staticConfig.runOnlyTag)))
+        if (!shouldRun(tags))
             return
 
         // if we already ran a test in this context we don't need to visit the child context now
@@ -135,6 +135,9 @@ internal class ContextVisitor<GivenType>(
 
         if (visitor.ranATest) ranATest = true
     }
+
+    private fun shouldRun(tags: Set<String>) =
+        !(!executeAll && (staticConfig.runOnlyTag != null && !tags.contains(staticConfig.runOnlyTag)))
 
     override suspend fun describe(
         name: String,

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -14,7 +14,7 @@ internal class ContextVisitor<GivenType>(
     private val resourcesCloser: ResourcesCloser,
     private val executeAll: Boolean = false,
     // indicate that this context was already executed once, so we already know about all of its tests.
-    // tgere is no need to check tests, just go into sub contexts
+    // there is no need to check tests, just go into sub contexts
     private val onlyRunSubcontexts: Boolean,
     private val rootContextStartTime: Long
 ) : ContextDSL<GivenType>, ResourcesDSL by resourcesCloser {

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -71,6 +71,12 @@ internal class ContextVisitor<GivenType>(
         if (!shouldRun(tags))
             return
 
+
+
+        val contextPath = ContextPath(context, name)
+        if (!staticConfig.testFilter.shouldRun(contextPath))
+            return
+
         // if we already ran a test in this context we don't need to visit the child context now
         if (this.isolation && ranATest) {
             // but we need to run the root context again to visit this child context
@@ -80,14 +86,10 @@ internal class ContextVisitor<GivenType>(
             return
         }
 
-        if (isolation == false)
-            contextStateCollector.containsContextsWithoutIsolation = true
-
-        val contextPath = ContextPath(context, name)
-        if (!staticConfig.testFilter.shouldRun(contextPath))
-            return
 
         if (contextStateCollector.finishedPaths.contains(contextPath)) return
+        if (isolation == false)
+            contextStateCollector.containsContextsWithoutIsolation = true
         val sourceInfo = sourceInfo()
         val subContextShouldHaveIsolation = isolation != false && this.isolation
         val context = Context(name, context, sourceInfo, subContextShouldHaveIsolation)
@@ -137,7 +139,7 @@ internal class ContextVisitor<GivenType>(
     }
 
     private fun shouldRun(tags: Set<String>) =
-        !(!executeAll && (staticConfig.runOnlyTag != null && !tags.contains(staticConfig.runOnlyTag)))
+        executeAll || (staticConfig.runOnlyTag == null || tags.contains(staticConfig.runOnlyTag))
 
     override suspend fun describe(
         name: String,

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -15,7 +15,7 @@ internal class ContextVisitor<GivenType>(
     private val contextExecutor: ContextExecutor,
     private val context: Context,
     private val resourcesCloser: ResourcesCloser,
-    // execute subcontexts and tests regardless of their tags, even when filtering
+    // execute sub-contexts and tests regardless of their tags, even when filtering
     private val executeAll: Boolean = false,
     val given: (suspend () -> GivenType)
 ) : ContextDSL<GivenType>, ResourcesDSL by resourcesCloser {
@@ -27,7 +27,7 @@ internal class ContextVisitor<GivenType>(
     // run with the TestExecutor.
     private var ranATest = false
     var contextsLeft = false // are there sub contexts left to run?
-    var mutable = true // we allow changes only to the current context to catch errors in the context structure
+    private var mutable = true // we allow changes only to the current context to catch errors in the context structure
 
     override suspend fun it(name: String, tags: Set<String>, function: TestLambda<GivenType>) {
         checkForDuplicateName(name)
@@ -208,7 +208,7 @@ internal class ContextVisitor<GivenType>(
         if (!mutable) {
             throw ImmutableContextException(
                 "Trying to create a test in the wrong context. " +
-                        "Make sure functions that create tests have ContextDSL as receiver"
+                    "Make sure functions that create tests have ContextDSL as receiver"
             )
         }
     }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -14,7 +14,9 @@ internal class ContextVisitor<GivenType>(
     // execute sub-contexts and tests regardless of their tags, even when filtering
     private val given: suspend () -> GivenType,
     private val resourcesCloser: ResourcesCloser,
-    private val executeAll: Boolean = false, // no need to run tests, just go into sub contexts)
+    private val executeAll: Boolean = false,
+    // indicate that this context was already executed once, so we already know about all of its tests.
+    // tgere is no need to check tests, just go into sub contexts
     private val onlyRunSubcontexts: Boolean,
     private val rootContextStartTime: Long
 ) : ContextDSL<GivenType>, ResourcesDSL by resourcesCloser {

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -1,0 +1,234 @@
+package failgood.internal.execution.context
+
+import failgood.*
+import failgood.Pending
+import failgood.internal.ContextPath
+import failgood.internal.ResourcesCloser
+import failgood.internal.SingleTestExecutor
+import failgood.internal.TestContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeout
+
+internal class ContextVisitor<GivenType>(
+    private val contextExecutor: ContextExecutor,
+    private val context: Context,
+    private val resourcesCloser: ResourcesCloser,
+    // execute subcontexts and tests regardless of their tags, even when filtering
+    private val executeAll: Boolean = false,
+    val given: (suspend () -> GivenType)
+) : ContextDSL<GivenType>, ResourcesDSL by resourcesCloser {
+    val isolation = context.isolation
+    private val contextInvestigated = contextExecutor.investigatedContexts.contains(context)
+    private val namesInThisContext = mutableSetOf<String>() // test and context names to detect duplicates
+
+    // we only run the first new test that we find here. the remaining tests of the context
+    // run with the TestExecutor.
+    private var ranATest = false
+    var contextsLeft = false // are there sub contexts left to run?
+    var mutable = true // we allow changes only to the current context to catch errors in the context structure
+
+    override suspend fun it(name: String, tags: Set<String>, function: TestLambda<GivenType>) {
+        checkForDuplicateName(name)
+        if (!executeAll && (contextExecutor.filteringByTag && !tags.contains(contextExecutor.onlyTag)))
+            return
+        val testPath = ContextPath(context, name)
+        if (!contextExecutor.testFilter.shouldRun(testPath))
+            return
+        // we process each test only once
+        if (!contextExecutor.processedTests.add(testPath)) {
+            return
+        }
+        val testDescription = TestDescription(context, name, sourceInfo())
+        if (!ranATest || !isolation) {
+            // if we don't need isolation we run all tests here.
+            // if we do:
+            // we did not yet run a test, so we are going to run this test ourselves
+            ranATest = true
+
+            contextExecutor.deferredTestResults[testDescription] =
+                contextExecutor.scope.async(start = contextExecutor.coroutineStart) {
+
+                    contextExecutor.listener.testStarted(testDescription)
+                    val testResult = executeTest(testDescription, function)
+                    val testPlusResult = TestPlusResult(testDescription, testResult)
+                    contextExecutor.listener.testFinished(testPlusResult)
+                    testPlusResult
+                }
+        } else {
+            val resourcesCloser = ResourcesCloser(contextExecutor.scope)
+            val deferred = contextExecutor.scope.async(start = contextExecutor.coroutineStart) {
+                contextExecutor.listener.testStarted(testDescription)
+                val testPlusResult = try {
+                    withTimeout(contextExecutor.timeoutMillis) {
+                        val result =
+                            SingleTestExecutor(
+                                contextExecutor.rootContext,
+                                testPath,
+                                TestContext(resourcesCloser, contextExecutor.listener, testDescription),
+                                resourcesCloser
+                            ).execute()
+                        TestPlusResult(testDescription, result)
+                    }
+                } catch (e: TimeoutCancellationException) {
+                    TestPlusResult(testDescription, Failure(e))
+                }
+                testPlusResult.also {
+                    contextExecutor.listener.testFinished(it)
+                }
+            }
+            contextExecutor.deferredTestResults[testDescription] = deferred
+        }
+    }
+
+    private suspend fun executeTest(
+        testDescription: TestDescription,
+        function: TestLambda<GivenType>
+    ): TestResult {
+        return try {
+            withTimeout(contextExecutor.timeoutMillis) {
+                val testContext = TestContext(resourcesCloser, contextExecutor.listener, testDescription)
+                try {
+                    testContext.function(given.invoke())
+                } catch (e: Throwable) {
+                    val failure = Failure(e)
+                    try {
+                        resourcesCloser.callAfterEach(testContext, failure)
+                    } catch (_: Throwable) {
+                    }
+                    if (isolation) try {
+                        resourcesCloser.closeAutoCloseables()
+                    } catch (_: Throwable) {
+                    }
+                    return@withTimeout failure
+                }
+                // test was successful
+                val success = Success((System.nanoTime() - contextExecutor.startTime) / 1000)
+                try {
+                    resourcesCloser.callAfterEach(testContext, success)
+                } catch (e: Throwable) {
+                    if (isolation) {
+                        try {
+                            resourcesCloser.closeAutoCloseables()
+                        } catch (e: Throwable) {
+                            return@withTimeout Failure(e)
+                        }
+                    }
+                    return@withTimeout Failure(e)
+                }
+                if (isolation) {
+                    try {
+                        resourcesCloser.closeAutoCloseables()
+                    } catch (e: Throwable) {
+                        return@withTimeout Failure(e)
+                    }
+                }
+                success
+            }
+        } catch (e: TimeoutCancellationException) {
+            Failure(e)
+        }
+    }
+
+    override suspend fun <ContextDependency> describe(
+        name: String,
+        tags: Set<String>,
+        isolation: Boolean?,
+        given: (suspend () -> ContextDependency),
+        contextLambda: suspend ContextDSL<ContextDependency>.() -> Unit
+    ) {
+        checkForDuplicateName(name)
+        if (!executeAll && (contextExecutor.filteringByTag && !tags.contains(contextExecutor.onlyTag)))
+            return
+        if (isolation == false)
+            contextExecutor.containsContextsWithoutIsolation = true
+
+        // if we already ran a test in this context we don't need to visit the child context now
+        if (this.isolation && ranATest) {
+            contextsLeft = true
+            // but we need to run the root context again to visit this child context
+            return
+        }
+        val contextPath = ContextPath(context, name)
+        if (!contextExecutor.testFilter.shouldRun(contextPath))
+            return
+
+        if (contextExecutor.processedTests.contains(contextPath)) return
+        val sourceInfo = sourceInfo()
+        val subContextShouldHaveIsolation = isolation != false && this.isolation
+        val context = Context(name, context, sourceInfo, subContextShouldHaveIsolation)
+        if (isolation == true && !this.isolation) {
+            contextExecutor.recordContextAsFailed(
+                context, sourceInfo, contextPath,
+                FailGoodException("in a context without isolation it can not be turned on again")
+            )
+            return
+        }
+        val visitor =
+            ContextVisitor(contextExecutor, context, resourcesCloser, contextExecutor.filteringByTag, given)
+        this.mutable = false
+        try {
+            visitor.mutable = true
+            visitor.contextLambda()
+            visitor.mutable = false
+            this.mutable = true
+            contextExecutor.investigatedContexts.add(context)
+        } catch (exceptionInContext: ImmutableContextException) {
+            // this is fatal, and we treat the whole root context as failed, so we just rethrow
+            throw exceptionInContext
+        } catch (exceptionInContext: Throwable) {
+            this.mutable = true
+            contextExecutor.recordContextAsFailed(context, sourceInfo, contextPath, exceptionInContext)
+            ranATest = true
+            return
+        }
+        if (visitor.contextsLeft) {
+            contextsLeft = true
+        } else {
+            contextExecutor.foundContexts.add(context)
+            contextExecutor.processedTests.add(contextPath)
+        }
+
+        if (visitor.ranATest) ranATest = true
+    }
+
+    override suspend fun describe(
+        name: String,
+        tags: Set<String>,
+        isolation: Boolean?,
+        function: ContextLambda
+    ) {
+        describe(name, tags, isolation, {}, function)
+    }
+
+    private fun checkForDuplicateName(name: String) {
+        if (!namesInThisContext.add(name))
+            throw DuplicateNameInContextException("duplicate name \"$name\" in context \"${context.name}\"")
+        if (!mutable) {
+            throw ImmutableContextException(
+                "Trying to create a test in the wrong context. " +
+                        "Make sure functions that create tests have ContextDSL as receiver"
+            )
+        }
+    }
+
+    override suspend fun ignore(name: String, function: TestLambda<GivenType>) {
+        val testPath = ContextPath(context, name)
+
+        if (contextExecutor.processedTests.add(testPath)) {
+            val testDescriptor =
+                TestDescription(context, name, sourceInfo())
+            val result = Pending
+
+            val testPlusResult = TestPlusResult(testDescriptor, result)
+            contextExecutor.deferredTestResults[testDescriptor] = CompletableDeferred(testPlusResult)
+            contextExecutor.listener.testFinished(testPlusResult)
+        }
+    }
+
+    override fun afterSuite(function: suspend () -> Unit) {
+        if (!contextInvestigated)
+            contextExecutor.afterSuiteCallbacks.add(function)
+    }
+}

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -148,9 +148,10 @@ internal class ContextVisitor<GivenType>(
         if (!executeAll && (staticConfig.runOnlyTag != null && !tags.contains(staticConfig.runOnlyTag)))
             return
 
+        // if we already ran a test in this context we don't need to visit the child context now
         if (this.isolation && ranATest) {
-            contextsLeft = true
             // but we need to run the root context again to visit this child context
+            contextsLeft = true
             if (onlyRunSubcontexts)
                 throw ContextFinished()
             return
@@ -159,7 +160,6 @@ internal class ContextVisitor<GivenType>(
         if (isolation == false)
             contextStateCollector.containsContextsWithoutIsolation = true
 
-        // if we already ran a test in this context we don't need to visit the child context now
         val contextPath = ContextPath(context, name)
         if (!staticConfig.testFilter.shouldRun(contextPath))
             return
@@ -190,8 +190,6 @@ internal class ContextVisitor<GivenType>(
         try {
             visitor.mutable = true
             visitor.contextLambda()
-            visitor.mutable = false
-            this.mutable = true
             contextStateCollector.investigatedContexts.add(context)
         } catch (_: ContextFinished) {
         } catch (exceptionInContext: ImmutableContextException) {
@@ -202,6 +200,7 @@ internal class ContextVisitor<GivenType>(
             ranATest = true
             return
         } finally {
+            visitor.mutable = false
             this.mutable = true
         }
         if (visitor.contextsLeft) {

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -61,7 +61,7 @@ internal class ContextVisitor<GivenType>(
                                 testPath,
                                 TestContext(resourcesCloser, staticConfig.listener, testDescription),
                                 resourcesCloser,
-                                staticConfig.rootContext.function
+                                staticConfig.rootContextLambda
                             ).execute()
                         TestPlusResult(testDescription, result)
                     }

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -71,8 +71,6 @@ internal class ContextVisitor<GivenType>(
         if (!shouldRun(tags))
             return
 
-
-
         val contextPath = ContextPath(context, name)
         if (!staticConfig.testFilter.shouldRun(contextPath))
             return
@@ -85,7 +83,6 @@ internal class ContextVisitor<GivenType>(
                 throw ContextFinished()
             return
         }
-
 
         if (contextStateCollector.finishedPaths.contains(contextPath)) return
         if (isolation == false)

--- a/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/ContextVisitor.kt
@@ -58,10 +58,10 @@ internal class ContextVisitor<GivenType>(
                     withTimeout(staticConfig.timeoutMillis) {
                         val result =
                             SingleTestExecutor(
-                                staticConfig.rootContext,
                                 testPath,
                                 TestContext(resourcesCloser, staticConfig.listener, testDescription),
-                                resourcesCloser
+                                resourcesCloser,
+                                staticConfig.rootContext.function
                             ).execute()
                         TestPlusResult(testDescription, result)
                     }

--- a/failgood/jvm/src/failgood/internal/execution/context/StaticContextExecutionConfig.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/StaticContextExecutionConfig.kt
@@ -1,15 +1,15 @@
 package failgood.internal.execution.context
 
+import failgood.ContextLambda
 import failgood.ExecutionListener
 import failgood.NullExecutionListener
-import failgood.RootContext
 import failgood.internal.ExecuteAllTests
 import failgood.internal.TestFilter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 
 internal data class StaticContextExecutionConfig(
-    val rootContext: RootContext,
+    val rootContextLambda: ContextLambda,
     val scope: CoroutineScope,
     val listener: ExecutionListener = NullExecutionListener,
     val testFilter: TestFilter = ExecuteAllTests,

--- a/failgood/jvm/src/failgood/internal/execution/context/StaticContextExecutionConfig.kt
+++ b/failgood/jvm/src/failgood/internal/execution/context/StaticContextExecutionConfig.kt
@@ -1,0 +1,19 @@
+package failgood.internal.execution.context
+
+import failgood.ExecutionListener
+import failgood.NullExecutionListener
+import failgood.RootContext
+import failgood.internal.ExecuteAllTests
+import failgood.internal.TestFilter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+
+internal data class StaticContextExecutionConfig(
+    val rootContext: RootContext,
+    val scope: CoroutineScope,
+    val listener: ExecutionListener = NullExecutionListener,
+    val testFilter: TestFilter = ExecuteAllTests,
+    val timeoutMillis: Long = 40000,
+    val coroutineStart: CoroutineStart = CoroutineStart.DEFAULT,
+    val runOnlyTag: String? = null
+)

--- a/failgood/jvm/test/failgood/docs/TestContextOnTopLevelExample.kt
+++ b/failgood/jvm/test/failgood/docs/TestContextOnTopLevelExample.kt
@@ -5,7 +5,7 @@ import failgood.Test
 import failgood.describe
 
 // this is just needed for unit tests that want to load this file
-val testContextsOnTopLevelExampleClassName = Throwable().stackTrace.first().className
+val testContextsOnTopLevelExampleClassName: String = Throwable().stackTrace.first().className
 
 val context =
     describe("test context declared on top level") {

--- a/failgood/jvm/test/failgood/internal/ResourcesCloserTest.kt
+++ b/failgood/jvm/test/failgood/internal/ResourcesCloserTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertNotNull
 @Test
 class ResourcesCloserTest {
     val context = describe(ResourcesCloser::class) {
-        val subject = coroutineScope { ResourcesCloser(this) }
+        val subject = coroutineScope { OnlyResourcesCloser(this) }
         describe(ResourcesCloser::closeAutoCloseables.name) {
             it("closes autoclosables") {
                 val autoCloseable = mock<AutoCloseable>()

--- a/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
@@ -59,11 +59,11 @@ class SingleTestExecutorTest {
             }
             it("also supports describe / it") {
                 val context: ContextLambda = {
-                        describe("with a valid root context") {
-                            it("returns number of tests") {}
-                            it("returns contexts") {}
-                        }
+                    describe("with a valid root context") {
+                        it("returns number of tests") {}
+                        it("returns contexts") {}
                     }
+                }
                 val test =
                     ContextPath(
                         Context("with a valid root context", Context("ContextExecutor", null)),

--- a/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
@@ -19,7 +19,7 @@ class SingleTestExecutorTest {
     val context =
         describe(SingleTestExecutor::class) {
             val testDSL = mock<TestDSL>()
-            val resourceCloser = coroutineScope { ResourcesCloser(this) }
+            val resourceCloser = coroutineScope { OnlyResourcesCloser(this) }
             describe("test execution") {
                 val events = mutableListOf<String>()
                 val ctx =

--- a/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
@@ -56,7 +56,7 @@ class SingleTestExecutorTest {
             }
             it("also supports describe / it") {
                 val context =
-                    describe(ContextExecutor::class) {
+                    failgood.describe("root") {
                         describe("with a valid root context") {
                             it("returns number of tests") {}
                             it("returns contexts") {}

--- a/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/SingleTestExecutorTest.kt
@@ -1,12 +1,6 @@
 package failgood.internal
 
-import failgood.Context
-import failgood.Failure
-import failgood.RootContext
-import failgood.Success
-import failgood.Test
-import failgood.TestDSL
-import failgood.describe
+import failgood.*
 import failgood.mock.mock
 import kotlinx.coroutines.coroutineScope
 import strikt.api.expectThat
@@ -22,41 +16,49 @@ class SingleTestExecutorTest {
             val resourceCloser = coroutineScope { OnlyResourcesCloser(this) }
             describe("test execution") {
                 val events = mutableListOf<String>()
-                val ctx =
-                    RootContext("root context") {
-                        events.add("root context")
-                        test("test 1") { events.add("test 1") }
-                        test("test 2") { events.add("test 2") }
-                        context("context 1") {
-                            events.add("context 1")
+                val ctx: ContextLambda = {
+                    events.add("root context")
+                    test("test 1") { events.add("test 1") }
+                    test("test 2") { events.add("test 2") }
+                    context("context 1") {
+                        events.add("context 1")
 
-                            context("context 2") {
-                                events.add("context 2")
-                                test("test 3") { events.add("test 3") }
-                            }
+                        context("context 2") {
+                            events.add("context 2")
+                            test("test 3") { events.add("test 3") }
                         }
                     }
+                }
                 val rootContext = Context("root context", null)
                 val context1 = Context("context 1", rootContext)
                 val context2 = Context("context 2", context1)
 
                 it("executes a single test") {
                     val result =
-                        SingleTestExecutor(ctx, ContextPath(rootContext, "test 1"), testDSL, resourceCloser).execute()
+                        SingleTestExecutor(
+                            ContextPath(rootContext, "test 1"),
+                            testDSL,
+                            resourceCloser,
+                            ctx
+                        ).execute()
                     expectThat(events).containsExactly("root context", "test 1")
                     expectThat(result).isA<Success>()
                 }
                 it("executes a nested single test") {
                     val result =
-                        SingleTestExecutor(ctx, ContextPath(context2, "test 3"), testDSL, resourceCloser).execute()
+                        SingleTestExecutor(
+                            ContextPath(context2, "test 3"),
+                            testDSL,
+                            resourceCloser,
+                            ctx
+                        ).execute()
                     expectThat(events)
                         .containsExactly("root context", "context 1", "context 2", "test 3")
                     expectThat(result).isA<Success>()
                 }
             }
             it("also supports describe / it") {
-                val context =
-                    failgood.describe("root") {
+                val context: ContextLambda = {
                         describe("with a valid root context") {
                             it("returns number of tests") {}
                             it("returns contexts") {}
@@ -67,7 +69,7 @@ class SingleTestExecutorTest {
                         Context("with a valid root context", Context("ContextExecutor", null)),
                         "returns contexts"
                     )
-                val executor = SingleTestExecutor(context, test, testDSL, resourceCloser)
+                val executor = SingleTestExecutor(test, testDSL, resourceCloser, context)
                 executor.execute()
             }
             describe("error handling") {
@@ -77,9 +79,9 @@ class SingleTestExecutorTest {
                         throw runtimeException
                     }
                     val result = SingleTestExecutor(
-                        contextThatThrows,
                         ContextPath(Context("root context", null), "test"),
-                        testDSL, resourceCloser
+                        testDSL,
+                        resourceCloser, contextThatThrows.function
                     ).execute()
                     expectThat(result).isA<Failure>().get { failure }.isEqualTo(runtimeException)
                 }
@@ -90,9 +92,9 @@ class SingleTestExecutorTest {
                         it("test") {}
                     }
                     val result = SingleTestExecutor(
-                        contextThatThrows,
                         ContextPath(Context("root context", null), "test"),
-                        testDSL, resourceCloser
+                        testDSL,
+                        resourceCloser, contextThatThrows.function
                     ).execute()
                     expectThat(result).isA<Failure>().get { failure }.isEqualTo(runtimeException)
                 }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextExecutorTest.kt
@@ -1,10 +1,11 @@
-package failgood.internal
+package failgood.internal.execution.context
 
 import failgood.Failure
 import failgood.RootContext
 import failgood.Success
 import failgood.Test
 import failgood.describe
+import failgood.internal.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitAll

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextExecutorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextExecutorTest.kt
@@ -393,7 +393,7 @@ class ContextExecutorTest {
 
     private suspend fun execute(context: RootContext, tag: String? = null): ContextResult {
         return coroutineScope {
-            ContextExecutor(context, this, onlyTag = tag).execute()
+            ContextExecutor(context, this, runOnlyTag = tag).execute()
         }
     }
 

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -2,10 +2,12 @@ package failgood.internal.execution.context
 
 import failgood.Context
 import failgood.RootContext
+import failgood.Test
 import failgood.describe
 import failgood.internal.ResourcesCloser
 import kotlinx.coroutines.coroutineScope
 
+@Test
 object ContextVisitorTest {
     val tests = describe<ContextVisitor<*>> {
         it("can be easily created") {

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -1,7 +1,6 @@
 package failgood.internal.execution.context
 
 import failgood.Context
-import failgood.RootContext
 import failgood.Test
 import failgood.describe
 import failgood.mock.mock
@@ -13,7 +12,7 @@ object ContextVisitorTest {
         it("can be easily created") {
             coroutineScope {
                 ContextVisitor(
-                    StaticContextExecutionConfig(RootContext {}, this),
+                    StaticContextExecutionConfig({}, this),
                     mock(),
                     Context("root"),
                     {},

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -18,7 +18,8 @@ object ContextVisitorTest {
                     Context("root"),
                     {},
                     mock(),
-                    onlyRunSubcontexts = false
+                    onlyRunSubcontexts = false,
+                    rootContextStartTime = 0
                 )
             }
         }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -11,9 +11,10 @@ object ContextVisitorTest {
     val tests = describe<ContextVisitor<*>> {
         it("can be easily created") {
             coroutineScope {
+                val staticConfig = StaticContextExecutionConfig({}, this)
                 ContextVisitor(
-                    staticConfig = StaticContextExecutionConfig({}, this),
-                    contextStateCollector = ContextStateCollector(mock(), false),
+                    staticConfig = staticConfig,
+                    contextStateCollector = ContextStateCollector(staticConfig, false),
                     context = Context("root"),
                     given = {},
                     resourcesCloser = mock(),

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -12,11 +12,11 @@ object ContextVisitorTest {
         it("can be easily created") {
             coroutineScope {
                 ContextVisitor(
-                    StaticContextExecutionConfig({}, this),
-                    mock(),
-                    Context("root"),
-                    {},
-                    mock(),
+                    staticConfig = StaticContextExecutionConfig({}, this),
+                    contextStateCollector = ContextStateCollector(mock(), false),
+                    context = Context("root"),
+                    given = {},
+                    resourcesCloser = mock(),
                     onlyRunSubcontexts = false,
                     rootContextStartTime = 0
                 )

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -1,22 +1,28 @@
 package failgood.internal.execution.context
 
 import failgood.Context
+import failgood.RootContext
 import failgood.Test
 import failgood.describe
 import failgood.mock.mock
+import kotlinx.coroutines.coroutineScope
 
 @Test
 object ContextVisitorTest {
     val tests = describe<ContextVisitor<*>> {
         it("can be easily created") {
-            ContextVisitor(
-                mock(),
-                Context("root"),
-                {},
-                mock(),
-                onlyRunSubcontexts = false,
-                runOnlyTag = null
-            )
+            coroutineScope {
+                ContextVisitor(
+                    StaticContextExecutionConfig(RootContext {}, this),
+                    mock(),
+                    Context("root"),
+                    runOnlyTag = null,
+                    {},
+                    mock(),
+                    onlyRunSubcontexts = false
+                )
+
+            }
         }
     }
 }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -1,24 +1,15 @@
 package failgood.internal.execution.context
 
 import failgood.Context
-import failgood.RootContext
 import failgood.Test
 import failgood.describe
-import failgood.internal.ResourcesCloser
-import kotlinx.coroutines.coroutineScope
+import failgood.mock.mock
 
 @Test
 object ContextVisitorTest {
     val tests = describe<ContextVisitor<*>> {
         it("can be easily created") {
-            coroutineScope {
-                ContextVisitor(
-                    ContextExecutor(
-                        RootContext("root") { }, this, false
-                    ),
-                    Context("root"), ResourcesCloser(this), given = {}
-                )
-            }
+            ContextVisitor(mock(), Context("root"), mock(), given = {}, onlyRunSubcontexts = false)
         }
     }
 }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -9,7 +9,14 @@ import failgood.mock.mock
 object ContextVisitorTest {
     val tests = describe<ContextVisitor<*>> {
         it("can be easily created") {
-            ContextVisitor(mock(), Context("root"), mock(), given = {}, onlyRunSubcontexts = false)
+            ContextVisitor(
+                mock(),
+                Context("root"),
+                {},
+                mock(),
+                onlyRunSubcontexts = false,
+                runOnlyTag = null
+            )
         }
     }
 }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -16,12 +16,10 @@ object ContextVisitorTest {
                     StaticContextExecutionConfig(RootContext {}, this),
                     mock(),
                     Context("root"),
-                    runOnlyTag = null,
                     {},
                     mock(),
                     onlyRunSubcontexts = false
                 )
-
             }
         }
     }

--- a/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
+++ b/failgood/jvm/test/failgood/internal/execution/context/ContextVisitorTest.kt
@@ -1,0 +1,22 @@
+package failgood.internal.execution.context
+
+import failgood.Context
+import failgood.RootContext
+import failgood.describe
+import failgood.internal.ResourcesCloser
+import kotlinx.coroutines.coroutineScope
+
+object ContextVisitorTest {
+    val tests = describe<ContextVisitor<*>> {
+        it("can be easily created") {
+            coroutineScope {
+                ContextVisitor(
+                    ContextExecutor(
+                        RootContext("root") { }, this, false
+                    ),
+                    Context("root"), ResourcesCloser(this), given = {}
+                )
+            }
+        }
+    }
+}

--- a/failgood/jvm/test/failgood/junit/it/JunitPlatformFunctionalTest.kt
+++ b/failgood/jvm/test/failgood/junit/it/JunitPlatformFunctionalTest.kt
@@ -134,7 +134,7 @@ class JunitPlatformFunctionalTest {
                 )
             }
         }
-        it("returns uniqueIds that it understands (uniqueid roundtrip test)") {
+        it("returns uniqueIds that it understands (uniqueid round-trip test)") {
             // run a test by className
             executeSingleTest(TestFixture::class, listener)
             expectThat(listener.rootResult.await()).get { status }.isEqualTo(TestExecutionResult.Status.SUCCESSFUL)


### PR DESCRIPTION
big refactoring to split the context executor into smaller classes. 
This will also make it pretty easy to run the ContextExecutor multi threaded to speed up test discovery. (and in a lot of cases  also test execution)