### PR TITLE
Rename timeout env variable

### DIFF
--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -29,7 +29,7 @@ class Suite(val contextProviders: Collection<ContextProvider>) {
     }
 
     // set timeout to the timeout in milliseconds, an empty string to turn it off
-    private val timeoutMillis: Long = when (val timeout = getenv("TIMEOUT")) {
+    private val timeoutMillis: Long = when (val timeout = getenv("FAILGOOD_TIMEOUT")) {
         null -> DEFAULT_TIMEOUT
         "" -> Long.MAX_VALUE
         else -> timeout.toLongOrNull() ?: throw FailGoodException("TIMEOUT must be a number or an empty string")

--- a/failgood/jvm/src/failgood/Suite.kt
+++ b/failgood/jvm/src/failgood/Suite.kt
@@ -37,10 +37,10 @@ class Suite(val contextProviders: Collection<ContextProvider>) {
     private val timeoutMillis: Long = getenv("TIMEOUT").let {
         when (it) {
             null -> DEFAULT_TIMEOUT
-            "" -> null
+            "" -> Long.MAX_VALUE
             else -> it.toLongOrNull() ?: throw FailGoodException("TIMEOUT must be a number or an empty string")
         }
-    } ?: Long.MAX_VALUE
+    }
 
     internal suspend fun findTests(
         coroutineScope: CoroutineScope,


### PR DESCRIPTION
The environment variable name `TIMEOUT` is unspecific and usually needs to be commented in a configuration file such as:
```properties
TIMEOUT=60 # Failgood timeout
```

Furthermore it could clash with other timeout variables.
Renaming it to `FAILGOOD_TIMEOUT` eliminates the need to document its configuration and mitigates the risk of name clashes.
```properties
FAILGOOD_TIMEOUT=60
```