### PR TITLE
fix run all tests in whole project with new junit engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Send executionStarted event for failed contexts. Idea will ignore executionFinished events for not started tests
   so the error message would not appear in the test runner. (it would appear in the console output of the test runner)
 - Fix some edge cases with the new junit engine.
+- Fix running "all tests in project" by adding a fake test, because idea does not tests when the initial test plan is empty
+
 
 ### Changed
 

--- a/failgood/src/failgood/junit/next/DynamicTestDescriptor.kt
+++ b/failgood/src/failgood/junit/next/DynamicTestDescriptor.kt
@@ -1,5 +1,6 @@
 package failgood.junit.next
 
+import failgood.FailGoodException
 import failgood.junit.appendContext
 import failgood.junit.appendTest
 import java.util.Optional
@@ -33,7 +34,9 @@ class DynamicTestDescriptor(
     override fun getParent(): Optional<TestDescriptor> = Optional.ofNullable(parent)
 
     override fun setParent(parent: TestDescriptor?) {
-        TODO("Not yet implemented")
+        // we don't allow changing our parent, but if junit calls us with the parent we already have that's ok
+        if (parent != this.parent)
+            throw IllegalStateException()
     }
 
     override fun getChildren(): MutableSet<out TestDescriptor> = children

--- a/failgood/src/failgood/junit/next/NewJunitEngine.kt
+++ b/failgood/src/failgood/junit/next/NewJunitEngine.kt
@@ -19,6 +19,7 @@ import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestEngine
 import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.discovery.ClasspathRootSelector
 import org.junit.platform.engine.support.descriptor.EngineDescriptor
 
 class NewJunitEngine : TestEngine {
@@ -49,9 +50,11 @@ class NewJunitEngine : TestEngine {
                 ?: return EngineDescriptor(uniqueId, FailGoodJunitTestEngineConstants.DISPLAY_NAME)
 
         return FailGoodEngineDescriptor(uniqueId, id, suiteAndFilters).also {
-            // add one fake child because IDEA does not call `execute` when the test plan is totally empty
-            // (but not always, only when running "all tests in Project" (instead of just one module)
-            it.addChild(DynamicTestDescriptor(TestPlanNode.Test("test", "test"), it))
+            // add one fake child because IDEA does not call `execute` when the test plan is totally empty.
+            // This does not happen always but only when running "all tests in Project" (instead of just one module)
+            // we try to detect this case and add a fake test
+            if (discoveryRequest.getSelectorsByType(ClasspathRootSelector::class.java).size > 1)
+                it.addChild(DynamicTestDescriptor(TestPlanNode.Test("test", "empty-test-please-ignore"), it))
             failureLogger.add("Engine Descriptor", it.toString())
 
             if (debug) {

--- a/failgood/src/failgood/junit/next/NewJunitEngine.kt
+++ b/failgood/src/failgood/junit/next/NewJunitEngine.kt
@@ -50,9 +50,9 @@ class NewJunitEngine : TestEngine {
                 ?: return EngineDescriptor(uniqueId, FailGoodJunitTestEngineConstants.DISPLAY_NAME)
 
         return FailGoodEngineDescriptor(uniqueId, id, suiteAndFilters).also {
-            // add one fake child because IDEA does not call `execute` when the test plan is totally empty.
+            // Add one fake child because IDEA does not call `execute` when the test plan is totally empty.
             // This does not happen always but only when running "all tests in Project" (instead of just one module)
-            // we try to detect this case and add a fake test
+            // We try to detect this case and add a fake test
             if (discoveryRequest.getSelectorsByType(ClasspathRootSelector::class.java).size > 1)
                 it.addChild(DynamicTestDescriptor(TestPlanNode.Test("test", "empty-test-please-ignore"), it))
             failureLogger.add("Engine Descriptor", it.toString())

--- a/failgood/src/failgood/junit/next/NewJunitEngine.kt
+++ b/failgood/src/failgood/junit/next/NewJunitEngine.kt
@@ -49,6 +49,9 @@ class NewJunitEngine : TestEngine {
                 ?: return EngineDescriptor(uniqueId, FailGoodJunitTestEngineConstants.DISPLAY_NAME)
 
         return FailGoodEngineDescriptor(uniqueId, id, suiteAndFilters).also {
+            // add one fake child because idea does not call execute when the test plan is totally empty
+            // (but not always, only when running all tests in project (instead of just one module)
+            it.addChild(DynamicTestDescriptor(TestPlanNode.Test("test", "test"), it))
             failureLogger.add("Engine Descriptor", it.toString())
 
             if (debug) {

--- a/failgood/src/failgood/junit/next/NewJunitEngine.kt
+++ b/failgood/src/failgood/junit/next/NewJunitEngine.kt
@@ -49,8 +49,8 @@ class NewJunitEngine : TestEngine {
                 ?: return EngineDescriptor(uniqueId, FailGoodJunitTestEngineConstants.DISPLAY_NAME)
 
         return FailGoodEngineDescriptor(uniqueId, id, suiteAndFilters).also {
-            // add one fake child because idea does not call execute when the test plan is totally empty
-            // (but not always, only when running all tests in project (instead of just one module)
+            // add one fake child because IDEA does not call `execute` when the test plan is totally empty
+            // (but not always, only when running "all tests in Project" (instead of just one module)
             it.addChild(DynamicTestDescriptor(TestPlanNode.Test("test", "test"), it))
             failureLogger.add("Engine Descriptor", it.toString())
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 kotlin.code.style=official
 org.gradle.parallel=true
 group=dev.failgood
-version=0.9.0
+version=0.9.1
 
 kotlin.build.report.output=file
 


### PR DESCRIPTION
It seems that idea does not even call the junit engine execute method when the discover method returns no tests. 
but only when running all tests in a project, not just the default "tests in module"

so in this pr we create a fake test in the initial reply. Maybe I should just file a youtrack issue for this. 