### PR TITLE
Logging Support

### DIFF
--- a/failgood/build.gradle.kts
+++ b/failgood/build.gradle.kts
@@ -20,6 +20,9 @@ plugins {
 dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     api("org.junit.platform:junit-platform-commons:$junitPlatformVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutinesVersion")
+    implementation("org.slf4j:slf4j-api:2.0.13")
+
     runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")
     // to enable running test in idea without having to add the dependency manually
     api("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
@@ -35,6 +38,11 @@ dependencies {
     testImplementation("io.projectreactor.tools:blockhound:1.0.9.RELEASE")
 
     testImplementation(kotlin("test"))
+    testImplementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
+    testImplementation("org.slf4j:slf4j-api:2.0.13")
+    testImplementation("ch.qos.logback:logback-classic:1.5.6")
+
+
 
     // for the tools that analyze what events jupiter tests generate.
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")

--- a/failgood/build.gradle.kts
+++ b/failgood/build.gradle.kts
@@ -1,6 +1,10 @@
 
 
-import failgood.versions.*
+import failgood.versions.coroutinesVersion
+import failgood.versions.junitJupiterVersion
+import failgood.versions.junitPlatformVersion
+import failgood.versions.pitestVersion
+import failgood.versions.striktVersion
 import info.solidsoft.gradle.pitest.PitestPluginExtension
 
 plugins {
@@ -39,8 +43,6 @@ dependencies {
     testImplementation("io.projectreactor.tools:blockhound:1.0.9.RELEASE")
 
     testImplementation(kotlin("test"))
-    testImplementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
-    testImplementation("org.slf4j:slf4j-api:2.0.13")
     testImplementation("ch.qos.logback:logback-classic:1.5.6")
 
 

--- a/failgood/build.gradle.kts
+++ b/failgood/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api("org.junit.platform:junit-platform-commons:$junitPlatformVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutinesVersion")
     implementation("org.slf4j:slf4j-api:2.0.13")
+    implementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
 
     runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")
     // to enable running test in idea without having to add the dependency manually

--- a/failgood/src/failgood/Suite.kt
+++ b/failgood/src/failgood/Suite.kt
@@ -3,6 +3,7 @@ package failgood
 import failgood.dsl.ContextFunction
 import failgood.internal.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.slf4j.MDCContext
 import kotlin.reflect.KClass
 
 internal const val DEFAULT_TIMEOUT: Long = 40000
@@ -22,7 +23,7 @@ data class Suite(val contextProviders: Collection<ContextProvider>, val repeat: 
             if (!silent)
                 println("starting test suite with parallelism = ${suiteExecutionContext.parallelism}")
             suiteExecutionContext.coroutineDispatcher.use { dispatcher ->
-                runBlocking(dispatcher) {
+                runBlocking(dispatcher + MDCContext()) {
                     val contextInfos =
                         findAndStartTests(
                             this,

--- a/failgood/src/failgood/internal/ResourceCloserImpl.kt
+++ b/failgood/src/failgood/internal/ResourceCloserImpl.kt
@@ -6,13 +6,15 @@ import failgood.TestResult
 import failgood.dsl.ContextOnlyResourceDSL
 import failgood.dsl.TestDSL
 import failgood.jvm.JVMTestDependency
-import java.util.concurrent.ConcurrentLinkedQueue
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class ResourceCloserImpl(private val scope: CoroutineScope) :
     ResourcesCloser, ContextOnlyResourceDSL {
+    private val logger = KotlinLogging.logger {}
     override fun <T> autoClose(wrapped: T, closeFunction: suspend (T) -> Unit): T {
         addCloseable(Closer(wrapped, closeFunction))
         return wrapped
@@ -46,11 +48,13 @@ internal class ResourceCloserImpl(private val scope: CoroutineScope) :
     }
 
     override suspend fun closeAutoCloseables() {
+        logger.debug { "calling ${closeables.size} auto closeables" }
         closeables.reversed().forEach { it.close() }
     }
 
     override suspend fun callAfterEach(testDSL: TestDSL, testResult: TestResult) {
         var error: Throwable? = null
+        logger.debug { "calling ${afterEachCallbacks.size} after each blocks" }
         afterEachCallbacks.forEach {
             try {
                 it.invoke(testDSL, testResult)

--- a/failgood/src/failgood/internal/SuiteExecutionContext.kt
+++ b/failgood/src/failgood/internal/SuiteExecutionContext.kt
@@ -3,6 +3,7 @@ package failgood.internal
 import failgood.internal.sysinfo.cpus
 import failgood.internal.util.getenv
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import java.util.concurrent.ExecutorService
@@ -18,7 +19,7 @@ class SuiteExecutionContext(parallelismOverride: Int? = null) : AutoCloseable {
         if (parallelism > 1) Executors.newWorkStealingPool(parallelism)
         else Executors.newSingleThreadExecutor()
 
-    val coroutineDispatcher = threadPool.asCoroutineDispatcher()
+    val coroutineDispatcher: ExecutorCoroutineDispatcher = threadPool.asCoroutineDispatcher()
     val scope = CoroutineScope(coroutineDispatcher)
 
     override fun close() {

--- a/failgood/src/failgood/internal/execution/ContextStateCollector.kt
+++ b/failgood/src/failgood/internal/execution/ContextStateCollector.kt
@@ -5,6 +5,8 @@ import failgood.dsl.TestFunction
 import failgood.internal.*
 import failgood.internal.given.GivenDSLHandler
 import kotlinx.coroutines.*
+import kotlinx.coroutines.slf4j.MDCContext
+import org.slf4j.MDC
 
 internal class ContextStateCollector<RootGiven>(
     private val staticConfig: StaticContextExecutionConfig<RootGiven>,
@@ -55,7 +57,7 @@ internal class ContextStateCollector<RootGiven>(
         rootContextStartTime: Long
     ) {
         deferredTestResults[testDescription] =
-            staticConfig.scope.async(start = staticConfig.coroutineStart) {
+            staticConfig.scope.async(MDCContext(), start = staticConfig.coroutineStart) {
                 val listener = staticConfig.listener
                 listener.testStarted(testDescription)
                 val testResult =
@@ -126,7 +128,7 @@ internal class ContextStateCollector<RootGiven>(
     fun executeTestLater(testDescription: TestDescription, testPath: ContextPath) {
         val resourcesCloser = ResourceCloserImpl(staticConfig.scope)
         val deferred =
-            staticConfig.scope.async(start = staticConfig.coroutineStart) {
+            staticConfig.scope.async(MDCContext(), start = staticConfig.coroutineStart) {
                 staticConfig.listener.testStarted(testDescription)
                 val testPlusResult =
                     try {

--- a/failgood/src/failgood/internal/execution/ContextVisitor.kt
+++ b/failgood/src/failgood/internal/execution/ContextVisitor.kt
@@ -1,13 +1,9 @@
 package failgood.internal.execution
 
-import failgood.Context
-import failgood.FailGoodException
-import failgood.Ignored
-import failgood.Skipped
-import failgood.TestDescription
-import failgood.TestPlusResult
+import failgood.*
 import failgood.dsl.*
-import failgood.dsl.TestFunction
+import failgood.dsl.ContextDSL
+import failgood.dsl.ResourcesDSL
 import failgood.internal.ContextPath
 import failgood.internal.ResourcesCloser
 import failgood.internal.given.GivenDSLHandler
@@ -79,7 +75,7 @@ internal class ContextVisitor<RootGiven, GivenType>(
         }
         val testDescription = TestDescription(context, name, sourceInfo())
         staticConfig.listener.testDiscovered(testDescription)
-        MDC.put("test", name)
+        MDC.put("test", testDescription.niceString())
         if (!ranATest || !isolation) {
             // if we don't need isolation we run all tests here.
             // if we do:

--- a/failgood/src/failgood/internal/execution/ContextVisitor.kt
+++ b/failgood/src/failgood/internal/execution/ContextVisitor.kt
@@ -12,6 +12,7 @@ import failgood.internal.ContextPath
 import failgood.internal.ResourcesCloser
 import failgood.internal.given.GivenDSLHandler
 import kotlinx.coroutines.CompletableDeferred
+import org.slf4j.MDC
 
 internal class ContextVisitor<RootGiven, GivenType>(
     private val staticConfig: StaticContextExecutionConfig<RootGiven>,
@@ -78,12 +79,12 @@ internal class ContextVisitor<RootGiven, GivenType>(
         }
         val testDescription = TestDescription(context, name, sourceInfo())
         staticConfig.listener.testDiscovered(testDescription)
+        MDC.put("test", name)
         if (!ranATest || !isolation) {
             // if we don't need isolation we run all tests here.
             // if we do:
             // we did not yet run a test, so we are going to run this test ourselves
             ranATest = true
-
             contextStateCollector.executeTest(
                 testDescription,
                 function,

--- a/failgood/src/failgood/junit/ExecutionListener.kt
+++ b/failgood/src/failgood/junit/ExecutionListener.kt
@@ -1,8 +1,14 @@
 package failgood.junit
 
-import failgood.*
+import failgood.Context
 import failgood.ExecutionListener
+import failgood.FailGoodException
+import failgood.Failure
 import failgood.Skipped
+import failgood.SourceInfo
+import failgood.Success
+import failgood.TestDescription
+import failgood.TestPlusResult
 import org.junit.platform.engine.EngineExecutionListener
 import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.engine.TestSource
@@ -85,11 +91,18 @@ internal class ExecutionListener(
             val testDescription = testPlusResult.test
             val descriptor = testMapper.getMapping(testDescription)
             when (testPlusResult.result) {
-                is Failure ->
+                is Failure -> {
+                    listener.reportingEntryPublished(
+                        descriptor,
+                        ReportEntry.from("test path", testDescription.niceString())
+                    )
+
                     listener.executionFinished(
                         descriptor,
                         TestExecutionResult.failed(testPlusResult.result.failure)
                     )
+                }
+
                 is Skipped -> {
                     // for skipped tests testStarted is not called, so we have to start parent
                     // contexts
@@ -97,6 +110,7 @@ internal class ExecutionListener(
                     startParentContexts(testDescription)
                     listener.executionSkipped(descriptor, testPlusResult.result.reason)
                 }
+
                 is Success ->
                     listener.executionFinished(descriptor, TestExecutionResult.successful())
             }

--- a/failgood/test/failgood/functional/LoggingTest.kt
+++ b/failgood/test/failgood/functional/LoggingTest.kt
@@ -2,16 +2,18 @@ package failgood.functional
 
 import failgood.Test
 import failgood.tests
-import io.github.oshai.kotlinlogging.KotlinLogging
+import org.slf4j.MDC
+import kotlin.test.assertNotNull
+
 
 @Test
 class LoggingTest {
-    private val logger = KotlinLogging.logger {}
-
     val tests = tests {
         describe("logging MDC") {
-            it("contains the test") {
-                logger.info { "Hello World!" }
+            it("contains the test name") {
+                val mdc = assertNotNull(MDC.get("test"))
+                assert(mdc.endsWith("> logging MDC > contains the test name"))
+                assert(mdc.startsWith("LoggingTest"))
             }
         }
     }

--- a/failgood/test/failgood/functional/LoggingTest.kt
+++ b/failgood/test/failgood/functional/LoggingTest.kt
@@ -1,0 +1,18 @@
+package failgood.functional
+
+import failgood.Test
+import failgood.tests
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+@Test
+class LoggingTest {
+    private val logger = KotlinLogging.logger {}
+
+    val tests = tests {
+        describe("logging MDC") {
+            it("contains the test") {
+                logger.info { "Hello World!" }
+            }
+        }
+    }
+}

--- a/failgood/test/failgood/functional/TestResourcesLifecycleTest.kt
+++ b/failgood/test/failgood/functional/TestResourcesLifecycleTest.kt
@@ -22,6 +22,7 @@ import strikt.assertions.isSameInstanceAs
 import strikt.assertions.isTrue
 import strikt.assertions.map
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 
 @Test
 class TestResourcesLifecycleTest {
@@ -171,8 +172,8 @@ class TestResourcesLifecycleTest {
                         }
                     }
 
-                    var afterEachCalled = 0
-                    var autoCloseCalled = 0
+                    val afterEachCalled = AtomicInteger(0)
+                    var autoCloseCalled = AtomicInteger(0)
                     fun suiteResult(
                         testsFail: Boolean,
                         afterEachFails: Boolean,
@@ -180,12 +181,12 @@ class TestResourcesLifecycleTest {
                     ) =
                         Suite {
                             autoClose(null) {
-                                autoCloseCalled++
+                                autoCloseCalled.incrementAndGet()
                                 if (autoCloseFails)
                                     throw RuntimeException("autoclose error message")
                             }
                             afterEach {
-                                afterEachCalled++
+                                afterEachCalled.incrementAndGet()
                                 if (afterEachFails)
                                     throw RuntimeException("aftereach error message")
                             }
@@ -200,8 +201,8 @@ class TestResourcesLifecycleTest {
 
                     fun assertOk(result: SuiteResult) {
                         softly {
-                            assert(autoCloseCalled == 2)
-                            assert(afterEachCalled == 2)
+                            assert(autoCloseCalled.get() == 2)
+                            assert(afterEachCalled.get() == 2)
                             assertFailedGracefully(result)
                         }
                     }

--- a/failgood/test/failgood/functional/TestResourcesLifecycleTest.kt
+++ b/failgood/test/failgood/functional/TestResourcesLifecycleTest.kt
@@ -9,8 +9,8 @@ import failgood.mock.call
 import failgood.mock.getCalls
 import failgood.mock.mock
 import failgood.mock.verify
+import failgood.softly.softly
 import failgood.testsAbout
-import java.util.concurrent.CopyOnWriteArrayList
 import strikt.api.expectThat
 import strikt.assertions.all
 import strikt.assertions.containsExactly
@@ -21,6 +21,7 @@ import strikt.assertions.isFalse
 import strikt.assertions.isSameInstanceAs
 import strikt.assertions.isTrue
 import strikt.assertions.map
+import java.util.concurrent.CopyOnWriteArrayList
 
 @Test
 class TestResourcesLifecycleTest {
@@ -197,49 +198,52 @@ class TestResourcesLifecycleTest {
                         }
                             .run(silent = true)
 
-                    describe("when the test fails and autoclose and aftereach work") {
-                        val result =
-                            suiteResult(
-                                testsFail = true,
-                                afterEachFails = false,
-                                autoCloseFails = false
-                            )
-                        it("calls autoclose callbacks") { assert(autoCloseCalled == 2) }
-                        it("calls afterEach callbacks") { assert(afterEachCalled == 2) }
-                        it("reports the test failure") { assertFailedGracefully(result) }
+                    fun assertOk(result: SuiteResult) {
+                        softly {
+                            assert(autoCloseCalled == 2)
+                            assert(afterEachCalled == 2)
+                            assertFailedGracefully(result)
+                        }
                     }
-                    describe("when the test fails and aftereach fails") {
-                        val result =
-                            suiteResult(
-                                testsFail = true,
-                                afterEachFails = true,
-                                autoCloseFails = false
-                            )
-                        it("calls autoclose callbacks") { assert(autoCloseCalled == 2) }
-                        it("calls afterEach callbacks") { assert(afterEachCalled == 2) }
-                        it("reports the test failure") { assertFailedGracefully(result) }
-                    }
-                    describe("when the test succeeds, autoclose fails and aftereach works") {
-                        val result =
-                            suiteResult(
-                                testsFail = false,
-                                afterEachFails = true,
-                                autoCloseFails = false
-                            )
-                        it("calls autoclose callbacks") { assert(autoCloseCalled == 2) }
-                        it("calls afterEach callbacks") { assert(afterEachCalled == 2) }
-                        it("reports the test failure") { assertFailedGracefully(result) }
-                    }
-                    describe("when the test and autoclose succeeds and aftereach fails") {
-                        val result =
-                            suiteResult(
-                                testsFail = false,
-                                afterEachFails = false,
-                                autoCloseFails = true
-                            )
-                        it("calls autoclose callbacks") { assert(autoCloseCalled == 2) }
-                        it("calls afterEach callbacks") { assert(afterEachCalled == 2) }
-                        it("reports the test failure") { assertFailedGracefully(result) }
+
+                    describe("calls autoCLose, afterEach and reports test Failure") {
+                        test("when the test fails and autoclose and aftereach work") {
+                            val result =
+                                suiteResult(
+                                    testsFail = true,
+                                    afterEachFails = false,
+                                    autoCloseFails = false
+                                )
+                            assertOk(result)
+                        }
+                        test("when the test fails and aftereach fails") {
+                            val result =
+                                suiteResult(
+                                    testsFail = true,
+                                    afterEachFails = true,
+                                    autoCloseFails = false
+                                )
+                            assertOk(result)
+                        }
+                        test("when the test succeeds, autoclose fails and aftereach works") {
+                            val result =
+                                suiteResult(
+                                    testsFail = false,
+                                    afterEachFails = true,
+                                    autoCloseFails = false
+                                )
+                            assertOk(result)
+                        }
+                        test("when the test and autoclose succeeds and aftereach fails") {
+                            val result =
+                                suiteResult(
+                                    testsFail = false,
+                                    afterEachFails = false,
+                                    autoCloseFails = true
+                                )
+                            assertOk(result)
+                        }
+
                     }
 
                     it("reports the test failure even when the close callback fails too") {

--- a/failgood/testResources/logback.xml
+++ b/failgood/testResources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%X{test}] %-5level %logger{36} - %msg %n</pattern>
+<!--
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %X%n</pattern>
+-->
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/failgood/testResources/logback.xml
+++ b/failgood/testResources/logback.xml
@@ -14,8 +14,12 @@
             <pattern>%d{HH:mm:ss.SSS} [%X{test}] %-5level %logger{36} - %msg %n</pattern>
         </encoder>
     </appender>
-
-    <root level="WARN">
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
         <appender-ref ref="FILE"/>
+    </appender>
+    <logger name="failgood.internal.ResourceCloserImpl" level="DEBUG"/>
+    <root level="WARN">
+        <appender-ref ref="ASYNC"/>
     </root>
 </configuration>

--- a/failgood/testResources/logback.xml
+++ b/failgood/testResources/logback.xml
@@ -7,8 +7,15 @@
 -->
         </encoder>
     </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>tests.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%X{test}] %-5level %logger{36} - %msg %n</pattern>
+        </encoder>
+    </appender>
 
-    <root level="info">
-        <appender-ref ref="CONSOLE"/>
+    <root level="WARN">
+        <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/failgood/testResources/logback.xml
+++ b/failgood/testResources/logback.xml
@@ -18,7 +18,7 @@
         <discardingThreshold>0</discardingThreshold>
         <appender-ref ref="FILE"/>
     </appender>
-    <logger name="failgood.internal.ResourceCloserImpl" level="DEBUG"/>
+    <!--    <logger name="failgood.internal.ResourceCloserImpl" level="DEBUG"/>-->
     <root level="WARN">
         <appender-ref ref="ASYNC"/>
     </root>


### PR DESCRIPTION
this PR adds slf4j MDC support to failgood. And it also adds some debug logging. 

This feature is developed in an interesting way: instead of TDDing the logging features I am adding the logging to find bugs in failgood itself, and when the logging is good enough I will add tests for it.

TODO:
- [x] write unit tests