### PR TITLE
make coroutines compileOnly, remove boms again

### DIFF
--- a/failgood/build.gradle.kts
+++ b/failgood/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.16")
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.0")
 
-    runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")
     // to enable running test in idea without having to add the dependency manually
     api("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     compileOnly("org.junit.platform:junit-platform-engine:$junitPlatformVersion")
@@ -46,6 +45,7 @@ dependencies {
     // for the tools that analyze what events jupiter tests generate.
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
+    testRuntimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")
 }
 sourceSets.main {
     java.srcDirs("src")

--- a/failgood/build.gradle.kts
+++ b/failgood/build.gradle.kts
@@ -20,9 +20,7 @@ plugins {
 // ./gradlew publishToSonatype closeSonatypeStagingRepository (or ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository)
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
-    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$coroutinesVersion"))
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     api("org.junit.platform:junit-platform-commons:$junitPlatformVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutinesVersion")
     implementation("org.slf4j:slf4j-api:2.0.16")


### PR DESCRIPTION
failgood should work for all kinds of projects with all coroutine and kotlin versions, so we just use what the project already uses.

this will also make it easier to use it in idea plugins